### PR TITLE
Added .style to HTMLElement

### DIFF
--- a/src/main/scala/org/scalajs/dom/Html.scala
+++ b/src/main/scala/org/scalajs/dom/Html.scala
@@ -3228,6 +3228,13 @@ class HTMLElement extends Element {
   var spellcheck: js.Boolean = ???
   var classList: DOMTokenList = ???
   var draggable: js.Boolean = ???
+
+  /**
+   * Returns an object that represents the element's style attribute.
+   * 
+   * MDN
+   */
+  var style: CSSStyleDeclaration = ???
 }
 
 


### PR DESCRIPTION
The .style property (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.style) was missing from HTMLElement.
