### PR TITLE
WebGL and TypedArrays support

### DIFF
--- a/src/main/scala/org/scalajs/dom/TypedArrays.scala
+++ b/src/main/scala/org/scalajs/dom/TypedArrays.scala
@@ -4,6 +4,7 @@
  * Based on https://www.khronos.org/registry/typedarray/specs/1.0/
  */
 package org.scalajs.dom
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._ 
 
@@ -42,171 +43,171 @@ trait TypedArrayCommon[T] extends js.Object {
   def subarray(start: js.Number, end: js.Number): T = ???
 }
 
-class Int8Array private (x: js.Any*) extends js.Object
+class Int8Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Int8Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Int8Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Int8Array) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Int8Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 1
 }
 
-class Uint8Array private (x: js.Any*) extends js.Object
+class Uint8Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint8Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint8Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint8Array) = this()
+  def this(array: js.Array[js.Number]) = this()
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint8Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 1
 }
 
-class Uint8ClampedArray private (x: js.Any*) extends js.Object
+class Uint8ClampedArray private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint8ClampedArray]{
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint8ClampedArray) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint8ClampedArray) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint8ClampedArray extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 1
 }
 
-class Int16Array private (x: js.Any*) extends js.Object
+class Int16Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Int16Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Int16Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Int16Array) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Int16Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 2
 }
 
-class Uint16Array private (x: js.Any*) extends js.Object
+class Uint16Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint16Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint16Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint16Array) = this()
+  def this(array: js.Array[js.Number]) = this()
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint16Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 2
 }
 
-class Uint16ClampedArray private (x: js.Any*) extends js.Object
+class Uint16ClampedArray private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint16ClampedArray] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint16ClampedArray) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint16ClampedArray) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint16ClampedArray extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 2
 }
 
-class Int32Array private (x: js.Any*) extends js.Object
+class Int32Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Int32Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Int32Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Int32Array) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Int32Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 4
 }
 
 
-class Uint32Array private (x: js.Any*) extends js.Object
+class Uint32Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint32Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint32Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])    
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint32Array) = this()
+  def this(array: js.Array[js.Number]) = this()    
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint32Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 4
 }
 
-class Uint32ClampedArray private (x: js.Any*) extends js.Object
+class Uint32ClampedArray private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Uint32ClampedArray] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Uint32ClampedArray) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Uint32ClampedArray) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Uint32ClampedArray extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 4
 }
 
-class Float32Array private (x: js.Any*) extends js.Object
+class Float32Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Float32Array] {
   
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Float32Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
- }
-
-object Float32Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  def this(length: js.Number) = this()
+  def this(array: Float32Array) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
-class Float64Array private (x: js.Any*) extends js.Object
+object Float32Array extends js.Object {
+  val BYTES_PER_ELEMENT: js.Number = 4
+}
+
+class Float64Array private () extends js.Object
     with ArrayBufferView
     with TypedArrayCommon[Float64Array] {
-  def this(length: js.Number) = this(length.asInstanceOf[js.Any])
-  def this(array: Float64Array) = this(array.asInstanceOf[js.Any])
-  def this(array: js.Array[js.Number]) = this(array.asInstanceOf[js.Any])  
-  def this(buffer: ArrayBuffer) = this(buffer.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any])
-  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this(buffer.asInstanceOf[js.Any], byteOffset.asInstanceOf[js.Any], length.asInstanceOf[js.Any])
+  def this(length: js.Number) = this()
+  def this(array: Float64Array) = this()
+  def this(array: js.Array[js.Number]) = this()  
+  def this(buffer: ArrayBuffer) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number) = this()
+  def this(buffer: ArrayBuffer, byteOffset: js.Number, length: js.Number) = this()
 }
 
 object Float64Array extends js.Object {
-  def BYTES_PER_ELEMENT: js.Number = ???
+  val BYTES_PER_ELEMENT: js.Number = 8
 }
 
 class DataView(buffer: ArrayBuffer, byteOffset: js.Number, byteLength: js.Number) extends js.Object

--- a/src/main/scala/org/scalajs/dom/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/WebGL.scala
@@ -4,7 +4,8 @@
  * Based on https://www.khronos.org/registry/webgl/specs/1.0/
  */
 
-package org.scalajs.dom;
+package org.scalajs.dom
+
 import scala.scalajs.js
 import js.annotation._
 
@@ -17,383 +18,454 @@ class WebGLContextAttributes extends js.Object {
   var preserveDrawingBuffer: js.Boolean = ???
 }
 
-class WebGLBuffer private extends js.Object
+class WebGLBuffer private () extends js.Object
 
-class WebGLFramebuffer private extends js.Object
+class WebGLFramebuffer private () extends js.Object
 
-class WebGLProgram private extends js.Object
+class WebGLProgram private () extends js.Object
 
-class WebGLRenderbuffer private extends js.Object
+class WebGLRenderbuffer private () extends js.Object
 
-class WebGLShader private extends js.Object
+class WebGLShader private () extends js.Object
 
-class WebGLTexture private extends js.Object
+class WebGLTexture private () extends js.Object
 
-class WebGLUniformLocation private extends js.Object
+class WebGLUniformLocation private () extends js.Object
 
-class WebGLActiveInfo private extends js.Object {
+class WebGLActiveInfo private () extends js.Object {
   def size: js.Number = ???
   def `type`: js.Number = ???
   def name: js.String = ???  
 }
 
-class WebGLShaderPrecisionFormat private extends js.Object {
+class WebGLShaderPrecisionFormat private () extends js.Object {
   def rangeMin: js.Number = ???
   def rangeMax: js.Number = ???
   def precision: js.Number = ???
 }
 
 object WebGLRenderingContext extends js.Object {
-  def COLOR_BUFFER_BIT: js.Number = ???
-  def DEPTH_BUFFER_BIT: js.Number = ???
-  def STATIC_DRAW: js.Number = ???
-  def DYNAMIC_DRAW: js.Number = ???
-    
-  def BUFFER_SIZE: js.Number = ???
-  def BUFFER_USAGE: js.Number = ???
-    
-  def CURRENT_VERTEX_ATTRIB: js.Number = ???
-    
+  /* ClearBufferMask */
+  val DEPTH_BUFFER_BIT = 0x00000100
+  val STENCIL_BUFFER_BIT = 0x00000400
+  val COLOR_BUFFER_BIT = 0x00004000
+  
+  /* BeginMode */
+  val POINTS = 0x0000
+  val LINES = 0x0001
+  val LINE_LOOP = 0x0002
+  val LINE_STRIP = 0x0003
+  val TRIANGLES = 0x0004
+  val TRIANGLE_STRIP = 0x0005
+  val TRIANGLE_FAN = 0x0006
+  
+  /* AlphaFunction (not supported in ES20) */
+  /*    NEVER */
+  /*    LESS */
+  /*    EQUAL */
+  /*    LEQUAL */
+  /*    GREATER */
+  /*    NOTEQUAL */
+  /*    GEQUAL */
+  /*    ALWAYS */
+  
+  /* BlendingFactorDest */
+  val ZERO = 0
+  val ONE = 1
+  val SRC_COLOR = 0x0300
+  val ONE_MINUS_SRC_COLOR = 0x0301
+  val SRC_ALPHA = 0x0302
+  val ONE_MINUS_SRC_ALPHA = 0x0303
+  val DST_ALPHA = 0x0304
+  val ONE_MINUS_DST_ALPHA = 0x0305
+  
+  /* BlendingFactorSrc */
+  /*    ZERO */
+  /*    ONE */
+  val DST_COLOR = 0x0306
+  val ONE_MINUS_DST_COLOR = 0x0307
+  val SRC_ALPHA_SATURATE = 0x0308
+  /*    SRC_ALPHA */
+  /*    ONE_MINUS_SRC_ALPHA */
+  /*    DST_ALPHA */
+  /*    ONE_MINUS_DST_ALPHA */
+  
+  /* BlendEquationSeparate */
+  val FUNC_ADD = 0x8006
+  val BLEND_EQUATION = 0x8009
+  val BLEND_EQUATION_RGB = 0x8009   /* same as BLEND_EQUATION */
+  val BLEND_EQUATION_ALPHA = 0x883D
+  
+  /* BlendSubtract */
+  val FUNC_SUBTRACT = 0x800A
+  val FUNC_REVERSE_SUBTRACT = 0x800B
+  
+  /* Separate Blend Functions */
+  val BLEND_DST_RGB = 0x80C8
+  val BLEND_SRC_RGB = 0x80C9
+  val BLEND_DST_ALPHA = 0x80CA
+  val BLEND_SRC_ALPHA = 0x80CB
+  val CONSTANT_COLOR = 0x8001
+  val ONE_MINUS_CONSTANT_COLOR = 0x8002
+  val CONSTANT_ALPHA = 0x8003
+  val ONE_MINUS_CONSTANT_ALPHA = 0x8004
+  val BLEND_COLOR = 0x8005
+  
+  /* Buffer Objects */
+  val ARRAY_BUFFER = 0x8892
+  val ELEMENT_ARRAY_BUFFER = 0x8893
+  val ARRAY_BUFFER_BINDING = 0x8894
+  val ELEMENT_ARRAY_BUFFER_BINDING = 0x8895
+  
+  val STREAM_DRAW = 0x88E0
+  val STATIC_DRAW = 0x88E4
+  val DYNAMIC_DRAW = 0x88E8
+  
+  val BUFFER_SIZE = 0x8764
+  val BUFFER_USAGE = 0x8765
+  
+  val CURRENT_VERTEX_ATTRIB = 0x8626
+  
   /* CullFaceMode */
-  def FRONT: js.Number = ???
-  def BACK: js.Number = ???
-  def FRONT_AND_BACK: js.Number = ???
-    
+  val FRONT = 0x0404
+  val BACK = 0x0405
+  val FRONT_AND_BACK = 0x0408
+  
   /* DepthFunction */
-  /*      NEVER */
-  /*      LESS */
-  /*      EQUAL */
-  /*      LEQUAL */
-  /*      GREATER */
-  /*      NOTEQUAL */
-  /*      GEQUAL */
-  /*      ALWAYS */
-    
+  /*    NEVER */
+  /*    LESS */
+  /*    EQUAL */
+  /*    LEQUAL */
+  /*    GREATER */
+  /*    NOTEQUAL */
+  /*    GEQUAL */
+  /*    ALWAYS */
+  
   /* EnableCap */
   /* TEXTURE_2D */
-  def CULL_FACE: js.Number = ???
-  def BLEND: js.Number = ???
-  def DITHER: js.Number = ???
-  def STENCIL_TEST: js.Number = ???
-  def DEPTH_TEST: js.Number = ???
-  def SCISSOR_TEST: js.Number = ???
-  def POLYGON_OFFSET_FILL: js.Number = ???
-  def SAMPLE_ALPHA_TO_COVERAGE: js.Number = ???
-  def SAMPLE_COVERAGE: js.Number = ???
-    
+  val CULL_FACE = 0x0B44
+  val BLEND = 0x0BE2
+  val DITHER = 0x0BD0
+  val STENCIL_TEST = 0x0B90
+  val DEPTH_TEST = 0x0B71
+  val SCISSOR_TEST = 0x0C11
+  val POLYGON_OFFSET_FILL = 0x8037
+  val SAMPLE_ALPHA_TO_COVERAGE = 0x809E
+  val SAMPLE_COVERAGE = 0x80A0
+  
   /* ErrorCode */
-  def NO_ERROR: js.Number = ???
-  def INVALID_ENUM: js.Number = ???
-  def INVALID_VALUE: js.Number = ???
-  def INVALID_OPERATION: js.Number = ???
-  def OUT_OF_MEMORY: js.Number = ???
-    
+  val NO_ERROR = 0
+  val INVALID_ENUM = 0x0500
+  val INVALID_VALUE = 0x0501
+  val INVALID_OPERATION = 0x0502
+  val OUT_OF_MEMORY = 0x0505
+  
   /* FrontFaceDirection */
-  def CW: js.Number = ???
-  def CCW: js.Number = ???
-    
+  val CW = 0x0900
+  val CCW = 0x0901
+  
   /* GetPName */
-  def LINE_WIDTH: js.Number = ???
-  def ALIASED_POINT_SIZE_RANGE: js.Number = ???
-  def ALIASED_LINE_WIDTH_RANGE: js.Number = ???
-  def CULL_FACE_MODE: js.Number = ???
-  def FRONT_FACE: js.Number = ???
-  def DEPTH_RANGE: js.Number = ???
-  def DEPTH_WRITEMASK: js.Number = ???
-  def DEPTH_CLEAR_VALUE: js.Number = ???
-  def DEPTH_FUNC: js.Number = ???
-  def STENCIL_CLEAR_VALUE: js.Number = ???
-  def STENCIL_FUNC: js.Number = ???
-  def STENCIL_FAIL: js.Number = ???
-  def STENCIL_PASS_DEPTH_FAIL: js.Number = ???
-  def STENCIL_PASS_DEPTH_PASS: js.Number = ???
-  def STENCIL_REF: js.Number = ???
-  def STENCIL_VALUE_MASK: js.Number = ???
-  def STENCIL_WRITEMASK: js.Number = ???
-  def STENCIL_BACK_FUNC: js.Number = ???
-  def STENCIL_BACK_FAIL: js.Number = ???
-  def STENCIL_BACK_PASS_DEPTH_FAIL: js.Number = ???
-  def STENCIL_BACK_PASS_DEPTH_PASS: js.Number = ???
-  def STENCIL_BACK_REF: js.Number = ???
-  def STENCIL_BACK_VALUE_MASK: js.Number = ???
-  def STENCIL_BACK_WRITEMASK: js.Number = ???
-  def VIEWPORT: js.Number = ???
-  def SCISSOR_BOX: js.Number = ???
-  /*      SCISSOR_TEST */
-  def COLOR_CLEAR_VALUE: js.Number = ???
-  def COLOR_WRITEMASK: js.Number = ???
-  def UNPACK_ALIGNMENT: js.Number = ???
-  def PACK_ALIGNMENT: js.Number = ???
-  def MAX_TEXTURE_SIZE: js.Number = ???
-  def MAX_VIEWPORT_DIMS: js.Number = ???
-  def SUBPIXEL_BITS: js.Number = ???
-  def RED_BITS: js.Number = ???
-  def GREEN_BITS: js.Number = ???
-  def BLUE_BITS: js.Number = ???
-  def ALPHA_BITS: js.Number = ???
-  def DEPTH_BITS: js.Number = ???
-  def STENCIL_BITS: js.Number = ???
-  def POLYGON_OFFSET_UNITS: js.Number = ???
-  /*      POLYGON_OFFSET_FILL */
-  def POLYGON_OFFSET_FACTOR: js.Number = ???
-  def TEXTURE_BINDING_2D: js.Number = ???
-  def SAMPLE_BUFFERS: js.Number = ???
-  def SAMPLES: js.Number = ???
-  def SAMPLE_COVERAGE_VALUE: js.Number = ???
-  def SAMPLE_COVERAGE_INVERT: js.Number = ???
-    
+  val LINE_WIDTH = 0x0B21
+  val ALIASED_POINT_SIZE_RANGE = 0x846D
+  val ALIASED_LINE_WIDTH_RANGE = 0x846E
+  val CULL_FACE_MODE = 0x0B45
+  val FRONT_FACE = 0x0B46
+  val DEPTH_RANGE = 0x0B70
+  val DEPTH_WRITEMASK = 0x0B72
+  val DEPTH_CLEAR_VALUE = 0x0B73
+  val DEPTH_FUNC = 0x0B74
+  val STENCIL_CLEAR_VALUE = 0x0B91
+  val STENCIL_FUNC = 0x0B92
+  val STENCIL_FAIL = 0x0B94
+  val STENCIL_PASS_DEPTH_FAIL = 0x0B95
+  val STENCIL_PASS_DEPTH_PASS = 0x0B96
+  val STENCIL_REF = 0x0B97
+  val STENCIL_VALUE_MASK = 0x0B93
+  val STENCIL_WRITEMASK = 0x0B98
+  val STENCIL_BACK_FUNC = 0x8800
+  val STENCIL_BACK_FAIL = 0x8801
+  val STENCIL_BACK_PASS_DEPTH_FAIL = 0x8802
+  val STENCIL_BACK_PASS_DEPTH_PASS = 0x8803
+  val STENCIL_BACK_REF = 0x8CA3
+  val STENCIL_BACK_VALUE_MASK = 0x8CA4
+  val STENCIL_BACK_WRITEMASK = 0x8CA5
+  val VIEWPORT = 0x0BA2
+  val SCISSOR_BOX = 0x0C10
+  /*    SCISSOR_TEST */
+  val COLOR_CLEAR_VALUE = 0x0C22
+  val COLOR_WRITEMASK = 0x0C23
+  val UNPACK_ALIGNMENT = 0x0CF5
+  val PACK_ALIGNMENT = 0x0D05
+  val MAX_TEXTURE_SIZE = 0x0D33
+  val MAX_VIEWPORT_DIMS = 0x0D3A
+  val SUBPIXEL_BITS = 0x0D50
+  val RED_BITS = 0x0D52
+  val GREEN_BITS = 0x0D53
+  val BLUE_BITS = 0x0D54
+  val ALPHA_BITS = 0x0D55
+  val DEPTH_BITS = 0x0D56
+  val STENCIL_BITS = 0x0D57
+  val POLYGON_OFFSET_UNITS = 0x2A00
+  /*    POLYGON_OFFSET_FILL */
+  val POLYGON_OFFSET_FACTOR = 0x8038
+  val TEXTURE_BINDING_2D = 0x8069
+  val SAMPLE_BUFFERS = 0x80A8
+  val SAMPLES = 0x80A9
+  val SAMPLE_COVERAGE_VALUE = 0x80AA
+  val SAMPLE_COVERAGE_INVERT = 0x80AB
+  
   /* GetTextureParameter */
-  /*      TEXTURE_MAG_FILTER */
-  /*      TEXTURE_MIN_FILTER */
-  /*      TEXTURE_WRAP_S */
-  /*      TEXTURE_WRAP_T */
-    
-  def COMPRESSED_TEXTURE_FORMATS: js.Number = ???
-    
+  /*    TEXTURE_MAG_FILTER */
+  /*    TEXTURE_MIN_FILTER */
+  /*    TEXTURE_WRAP_S */
+  /*    TEXTURE_WRAP_T */
+  
+  val COMPRESSED_TEXTURE_FORMATS = 0x86A3
+  
   /* HintMode */
-  def DONT_CARE: js.Number = ???
-  def FASTEST: js.Number = ???
-  def NICEST: js.Number = ???
-    
+  val DONT_CARE = 0x1100
+  val FASTEST = 0x1101
+  val NICEST = 0x1102
+  
   /* HintTarget */
-  def GENERATE_MIPMAP_HINT: js.Number = ???
-    
+  val GENERATE_MIPMAP_HINT = 0x8192
+  
   /* DataType */
-  def BYTE: js.Number = ???
-  def UNSIGNED_BYTE: js.Number = ???
-  def SHORT: js.Number = ???
-  def UNSIGNED_SHORT: js.Number = ???
-  def INT: js.Number = ???
-  def UNSIGNED_INT: js.Number = ???
-  def FLOAT: js.Number = ???
-    
+  val BYTE = 0x1400
+  val UNSIGNED_BYTE = 0x1401
+  val SHORT = 0x1402
+  val UNSIGNED_SHORT = 0x1403
+  val INT = 0x1404
+  val UNSIGNED_INT = 0x1405
+  val FLOAT = 0x1406
+  
   /* PixelFormat */
-  def DEPTH_COMPONENT: js.Number = ???
-  def ALPHA: js.Number = ???
-  def RGB: js.Number = ???
-  def RGBA: js.Number = ???
-  def LUMINANCE: js.Number = ???
-  def LUMINANCE_ALPHA: js.Number = ???
-    
+  val DEPTH_COMPONENT = 0x1902
+  val ALPHA = 0x1906
+  val RGB = 0x1907
+  val RGBA = 0x1908
+  val LUMINANCE = 0x1909
+  val LUMINANCE_ALPHA = 0x190A
+  
   /* PixelType */
-  /*      UNSIGNED_BYTE */
-  def UNSIGNED_SHORT_4_4_4_4: js.Number = ???
-  def UNSIGNED_SHORT_5_5_5_1: js.Number = ???
-  def UNSIGNED_SHORT_5_6_5: js.Number = ???
-    
+  /*    UNSIGNED_BYTE */
+  val UNSIGNED_SHORT_4_4_4_4 = 0x8033
+  val UNSIGNED_SHORT_5_5_5_1 = 0x8034
+  val UNSIGNED_SHORT_5_6_5 = 0x8363
+  
   /* Shaders */
-  def FRAGMENT_SHADER: js.Number = ???
-  def VERTEX_SHADER: js.Number = ???
-  def MAX_VERTEX_ATTRIBS: js.Number = ???
-  def MAX_VERTEX_UNIFORM_VECTORS: js.Number = ???
-  def MAX_VARYING_VECTORS: js.Number = ???
-  def MAX_COMBINED_TEXTURE_IMAGE_UNITS: js.Number = ???
-  def MAX_VERTEX_TEXTURE_IMAGE_UNITS: js.Number = ???
-  def MAX_TEXTURE_IMAGE_UNITS: js.Number = ???
-  def MAX_FRAGMENT_UNIFORM_VECTORS: js.Number = ???
-  def SHADER_TYPE: js.Number = ???
-  def DELETE_STATUS: js.Number = ???
-  def LINK_STATUS: js.Number = ???
-  def VALIDATE_STATUS: js.Number = ???
-  def ATTACHED_SHADERS: js.Number = ???
-  def ACTIVE_UNIFORMS: js.Number = ???
-  def ACTIVE_ATTRIBUTES: js.Number = ???
-  def SHADING_LANGUAGE_VERSION: js.Number = ???
-  def CURRENT_PROGRAM: js.Number = ???
-    
+  val FRAGMENT_SHADER = 0x8B30
+  val VERTEX_SHADER = 0x8B31
+  val MAX_VERTEX_ATTRIBS = 0x8869
+  val MAX_VERTEX_UNIFORM_VECTORS = 0x8DFB
+  val MAX_VARYING_VECTORS = 0x8DFC
+  val MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8B4D
+  val MAX_VERTEX_TEXTURE_IMAGE_UNITS = 0x8B4C
+  val MAX_TEXTURE_IMAGE_UNITS = 0x8872
+  val MAX_FRAGMENT_UNIFORM_VECTORS = 0x8DFD
+  val SHADER_TYPE = 0x8B4F
+  val DELETE_STATUS = 0x8B80
+  val LINK_STATUS = 0x8B82
+  val VALIDATE_STATUS = 0x8B83
+  val ATTACHED_SHADERS = 0x8B85
+  val ACTIVE_UNIFORMS = 0x8B86
+  val ACTIVE_ATTRIBUTES = 0x8B89
+  val SHADING_LANGUAGE_VERSION = 0x8B8C
+  val CURRENT_PROGRAM = 0x8B8D
+  
   /* StencilFunction */
-  def NEVER: js.Number = ???
-  def LESS: js.Number = ???
-  def EQUAL: js.Number = ???
-  def LEQUAL: js.Number = ???
-  def GREATER: js.Number = ???
-  def NOTEQUAL: js.Number = ???
-  def GEQUAL: js.Number = ???
-  def ALWAYS: js.Number = ???
-    
+  val NEVER = 0x0200
+  val LESS = 0x0201
+  val EQUAL = 0x0202
+  val LEQUAL = 0x0203
+  val GREATER = 0x0204
+  val NOTEQUAL = 0x0205
+  val GEQUAL = 0x0206
+  val ALWAYS = 0x0207
+  
   /* StencilOp */
-  /*      ZERO */
-  def KEEP: js.Number = ???
-  def REPLACE: js.Number = ???
-  def INCR: js.Number = ???
-  def DECR: js.Number = ???
-  def INVERT: js.Number = ???
-  def INCR_WRAP: js.Number = ???
-  def DECR_WRAP: js.Number = ???
-    
+  /*    ZERO */
+  val KEEP = 0x1E00
+  val REPLACE = 0x1E01
+  val INCR = 0x1E02
+  val DECR = 0x1E03
+  val INVERT = 0x150A
+  val INCR_WRAP = 0x8507
+  val DECR_WRAP = 0x8508
+  
   /* StringName */
-  def VENDOR: js.Number = ???
-  def RENDERER: js.Number = ???
-  def VERSION: js.Number = ???
-    
+  val VENDOR = 0x1F00
+  val RENDERER = 0x1F01
+  val VERSION = 0x1F02
+  
   /* TextureMagFilter */
-  def NEAREST: js.Number = ???
-  def LINEAR: js.Number = ???
-    
+  val NEAREST = 0x2600
+  val LINEAR = 0x2601
+  
   /* TextureMinFilter */
-  /*      NEAREST */
-  /*      LINEAR */
-  def NEAREST_MIPMAP_NEAREST: js.Number = ???
-  def LINEAR_MIPMAP_NEAREST: js.Number = ???
-  def NEAREST_MIPMAP_LINEAR: js.Number = ???
-  def LINEAR_MIPMAP_LINEAR: js.Number = ???
-    
+  /*    NEAREST */
+  /*    LINEAR */
+  val NEAREST_MIPMAP_NEAREST = 0x2700
+  val LINEAR_MIPMAP_NEAREST = 0x2701
+  val NEAREST_MIPMAP_LINEAR = 0x2702
+  val LINEAR_MIPMAP_LINEAR = 0x2703
+  
   /* TextureParameterName */
-  def TEXTURE_MAG_FILTER: js.Number = ???
-  def TEXTURE_MIN_FILTER: js.Number = ???
-  def TEXTURE_WRAP_S: js.Number = ???
-  def TEXTURE_WRAP_T: js.Number = ???
-    
+  val TEXTURE_MAG_FILTER = 0x2800
+  val TEXTURE_MIN_FILTER = 0x2801
+  val TEXTURE_WRAP_S = 0x2802
+  val TEXTURE_WRAP_T = 0x2803
+  
   /* TextureTarget */
-  def TEXTURE_2D: js.Number = ???
-  def TEXTURE: js.Number = ???
-    
-  def TEXTURE_CUBE_MAP: js.Number = ???
-  def TEXTURE_BINDING_CUBE_MAP: js.Number = ???
-  def TEXTURE_CUBE_MAP_POSITIVE_X: js.Number = ???
-  def TEXTURE_CUBE_MAP_NEGATIVE_X: js.Number = ???
-  def TEXTURE_CUBE_MAP_POSITIVE_Y: js.Number = ???
-  def TEXTURE_CUBE_MAP_NEGATIVE_Y: js.Number = ???
-  def TEXTURE_CUBE_MAP_POSITIVE_Z: js.Number = ???
-  def TEXTURE_CUBE_MAP_NEGATIVE_Z: js.Number = ???
-  def MAX_CUBE_MAP_TEXTURE_SIZE: js.Number = ???
-    
+  val TEXTURE_2D = 0x0DE1
+  val TEXTURE = 0x1702
+  
+  val TEXTURE_CUBE_MAP = 0x8513
+  val TEXTURE_BINDING_CUBE_MAP = 0x8514
+  val TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515
+  val TEXTURE_CUBE_MAP_NEGATIVE_X = 0x8516
+  val TEXTURE_CUBE_MAP_POSITIVE_Y = 0x8517
+  val TEXTURE_CUBE_MAP_NEGATIVE_Y = 0x8518
+  val TEXTURE_CUBE_MAP_POSITIVE_Z = 0x8519
+  val TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851A
+  val MAX_CUBE_MAP_TEXTURE_SIZE = 0x851C
+  
   /* TextureUnit */
-  def TEXTURE0: js.Number = ???
-  def TEXTURE1: js.Number = ???
-  def TEXTURE2: js.Number = ???
-  def TEXTURE3: js.Number = ???
-  def TEXTURE4: js.Number = ???
-  def TEXTURE5: js.Number = ???
-  def TEXTURE6: js.Number = ???
-  def TEXTURE7: js.Number = ???
-  def TEXTURE8: js.Number = ???
-  def TEXTURE9: js.Number = ???
-  def TEXTURE10: js.Number = ???
-  def TEXTURE11: js.Number = ???
-  def TEXTURE12: js.Number = ???
-  def TEXTURE13: js.Number = ???
-  def TEXTURE14: js.Number = ???
-  def TEXTURE15: js.Number = ???
-  def TEXTURE16: js.Number = ???
-  def TEXTURE17: js.Number = ???
-  def TEXTURE18: js.Number = ???
-  def TEXTURE19: js.Number = ???
-  def TEXTURE20: js.Number = ???
-  def TEXTURE21: js.Number = ???
-  def TEXTURE22: js.Number = ???
-  def TEXTURE23: js.Number = ???
-  def TEXTURE24: js.Number = ???
-  def TEXTURE25: js.Number = ???
-  def TEXTURE26: js.Number = ???
-  def TEXTURE27: js.Number = ???
-  def TEXTURE28: js.Number = ???
-  def TEXTURE29: js.Number = ???
-  def TEXTURE30: js.Number = ???
-  def TEXTURE31: js.Number = ???
-  def ACTIVE_TEXTURE: js.Number = ???
-    
+  val TEXTURE0 = 0x84C0
+  val TEXTURE1 = 0x84C1
+  val TEXTURE2 = 0x84C2
+  val TEXTURE3 = 0x84C3
+  val TEXTURE4 = 0x84C4
+  val TEXTURE5 = 0x84C5
+  val TEXTURE6 = 0x84C6
+  val TEXTURE7 = 0x84C7
+  val TEXTURE8 = 0x84C8
+  val TEXTURE9 = 0x84C9
+  val TEXTURE10 = 0x84CA
+  val TEXTURE11 = 0x84CB
+  val TEXTURE12 = 0x84CC
+  val TEXTURE13 = 0x84CD
+  val TEXTURE14 = 0x84CE
+  val TEXTURE15 = 0x84CF
+  val TEXTURE16 = 0x84D0
+  val TEXTURE17 = 0x84D1
+  val TEXTURE18 = 0x84D2
+  val TEXTURE19 = 0x84D3
+  val TEXTURE20 = 0x84D4
+  val TEXTURE21 = 0x84D5
+  val TEXTURE22 = 0x84D6
+  val TEXTURE23 = 0x84D7
+  val TEXTURE24 = 0x84D8
+  val TEXTURE25 = 0x84D9
+  val TEXTURE26 = 0x84DA
+  val TEXTURE27 = 0x84DB
+  val TEXTURE28 = 0x84DC
+  val TEXTURE29 = 0x84DD
+  val TEXTURE30 = 0x84DE
+  val TEXTURE31 = 0x84DF
+  val ACTIVE_TEXTURE = 0x84E0
+  
   /* TextureWrapMode */
-  def REPEAT: js.Number = ???
-  def CLAMP_TO_EDGE: js.Number = ???
-  def MIRRORED_REPEAT: js.Number = ???
-    
+  val REPEAT = 0x2901
+  val CLAMP_TO_EDGE = 0x812F
+  val MIRRORED_REPEAT = 0x8370
+  
   /* Uniform Types */
-  def FLOAT_VEC2: js.Number = ???
-  def FLOAT_VEC3: js.Number = ???
-  def FLOAT_VEC4: js.Number = ???
-  def INT_VEC2: js.Number = ???
-  def INT_VEC3: js.Number = ???
-  def INT_VEC4: js.Number = ???
-  def BOOL: js.Number = ???
-  def BOOL_VEC2: js.Number = ???
-  def BOOL_VEC3: js.Number = ???
-  def BOOL_VEC4: js.Number = ???
-  def FLOAT_MAT2: js.Number = ???
-  def FLOAT_MAT3: js.Number = ???
-  def FLOAT_MAT4: js.Number = ???
-  def SAMPLER_2D: js.Number = ???
-  def SAMPLER_CUBE: js.Number = ???
-    
+  val FLOAT_VEC2 = 0x8B50
+  val FLOAT_VEC3 = 0x8B51
+  val FLOAT_VEC4 = 0x8B52
+  val INT_VEC2 = 0x8B53
+  val INT_VEC3 = 0x8B54
+  val INT_VEC4 = 0x8B55
+  val BOOL = 0x8B56
+  val BOOL_VEC2 = 0x8B57
+  val BOOL_VEC3 = 0x8B58
+  val BOOL_VEC4 = 0x8B59
+  val FLOAT_MAT2 = 0x8B5A
+  val FLOAT_MAT3 = 0x8B5B
+  val FLOAT_MAT4 = 0x8B5C
+  val SAMPLER_2D = 0x8B5E
+  val SAMPLER_CUBE = 0x8B60
+  
   /* Vertex Arrays */
-  def VERTEX_ATTRIB_ARRAY_ENABLED: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_SIZE: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_STRIDE: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_TYPE: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_NORMALIZED: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_POINTER: js.Number = ???
-  def VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: js.Number = ???
-    
+  val VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622
+  val VERTEX_ATTRIB_ARRAY_SIZE = 0x8623
+  val VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624
+  val VERTEX_ATTRIB_ARRAY_TYPE = 0x8625
+  val VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886A
+  val VERTEX_ATTRIB_ARRAY_POINTER = 0x8645
+  val VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889F
+  
   /* Shader Source */
-  def COMPILE_STATUS: js.Number = ???
-    
+  val COMPILE_STATUS = 0x8B81
+  
   /* Shader Precision-Specified Types */
-  def LOW_FLOAT: js.Number = ???
-  def MEDIUM_FLOAT: js.Number = ???
-  def HIGH_FLOAT: js.Number = ???
-  def LOW_INT: js.Number = ???
-  def MEDIUM_INT: js.Number = ???
-  def HIGH_INT: js.Number = ???
-    
+  val LOW_FLOAT = 0x8DF0
+  val MEDIUM_FLOAT = 0x8DF1
+  val HIGH_FLOAT = 0x8DF2
+  val LOW_INT = 0x8DF3
+  val MEDIUM_INT = 0x8DF4
+  val HIGH_INT = 0x8DF5
+  
   /* Framebuffer Object. */
-  def FRAMEBUFFER: js.Number = ???
-  def RENDERBUFFER: js.Number = ???
-    
-  def RGBA4: js.Number = ???
-  def RGB5_A1: js.Number = ???
-  def RGB565: js.Number = ???
-  def DEPTH_COMPONENT16: js.Number = ???
-  def STENCIL_INDEX: js.Number = ???
-  def STENCIL_INDEX8: js.Number = ???
-  def DEPTH_STENCIL: js.Number = ???
-    
-  def RENDERBUFFER_WIDTH: js.Number = ???
-  def RENDERBUFFER_HEIGHT: js.Number = ???
-  def RENDERBUFFER_INTERNAL_FORMAT: js.Number = ???
-  def RENDERBUFFER_RED_SIZE: js.Number = ???
-  def RENDERBUFFER_GREEN_SIZE: js.Number = ???
-  def RENDERBUFFER_BLUE_SIZE: js.Number = ???
-  def RENDERBUFFER_ALPHA_SIZE: js.Number = ???
-  def RENDERBUFFER_DEPTH_SIZE: js.Number = ???
-  def RENDERBUFFER_STENCIL_SIZE: js.Number = ???
-    
-  def FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: js.Number = ???
-  def FRAMEBUFFER_ATTACHMENT_OBJECT_NAME: js.Number = ???
-  def FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: js.Number = ???
-  def FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: js.Number = ???
-    
-  def COLOR_ATTACHMENT0: js.Number = ???
-  def DEPTH_ATTACHMENT: js.Number = ???
-  def STENCIL_ATTACHMENT: js.Number = ???
-  def DEPTH_STENCIL_ATTACHMENT: js.Number = ???
-    
-  def NONE: js.Number = ???
-    
-  def FRAMEBUFFER_COMPLETE: js.Number = ???
-  def FRAMEBUFFER_INCOMPLETE_ATTACHMENT: js.Number = ???
-  def FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: js.Number = ???
-  def FRAMEBUFFER_INCOMPLETE_DIMENSIONS: js.Number = ???
-  def FRAMEBUFFER_UNSUPPORTED: js.Number = ???
-    
-  def FRAMEBUFFER_BINDING: js.Number = ???
-  def RENDERBUFFER_BINDING: js.Number = ???
-  def MAX_RENDERBUFFER_SIZE: js.Number = ???
-    
-  def INVALID_FRAMEBUFFER_OPERATION: js.Number = ???
-    
+  val FRAMEBUFFER = 0x8D40
+  val RENDERBUFFER = 0x8D41
+  
+  val RGBA4 = 0x8056
+  val RGB5_A1 = 0x8057
+  val RGB565 = 0x8D62
+  val DEPTH_COMPONENT16 = 0x81A5
+  val STENCIL_INDEX = 0x1901
+  val STENCIL_INDEX8 = 0x8D48
+  val DEPTH_STENCIL = 0x84F9
+  
+  val RENDERBUFFER_WIDTH = 0x8D42
+  val RENDERBUFFER_HEIGHT = 0x8D43
+  val RENDERBUFFER_INTERNAL_FORMAT = 0x8D44
+  val RENDERBUFFER_RED_SIZE = 0x8D50
+  val RENDERBUFFER_GREEN_SIZE = 0x8D51
+  val RENDERBUFFER_BLUE_SIZE = 0x8D52
+  val RENDERBUFFER_ALPHA_SIZE = 0x8D53
+  val RENDERBUFFER_DEPTH_SIZE = 0x8D54
+  val RENDERBUFFER_STENCIL_SIZE = 0x8D55
+  
+  val FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE = 0x8CD0
+  val FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8CD1
+  val FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL = 0x8CD2
+  val FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE = 0x8CD3
+  
+  val COLOR_ATTACHMENT0 = 0x8CE0
+  val DEPTH_ATTACHMENT = 0x8D00
+  val STENCIL_ATTACHMENT = 0x8D20
+  val DEPTH_STENCIL_ATTACHMENT = 0x821A
+  
+  val NONE = 0
+  
+  val FRAMEBUFFER_COMPLETE = 0x8CD5
+  val FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8CD6
+  val FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8CD7
+  val FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8CD9
+  val FRAMEBUFFER_UNSUPPORTED = 0x8CDD
+  
+  val FRAMEBUFFER_BINDING = 0x8CA6
+  val RENDERBUFFER_BINDING = 0x8CA7
+  val MAX_RENDERBUFFER_SIZE = 0x84E8
+  
+  val INVALID_FRAMEBUFFER_OPERATION = 0x0506
+  
   /* WebGL-specific enums */
-  def UNPACK_FLIP_Y_WEBGL: js.Number = ???
-  def UNPACK_PREMULTIPLY_ALPHA_WEBGL: js.Number = ???
-  def CONTEXT_LOST_WEBGL: js.Number = ???
-  def UNPACK_COLORSPACE_CONVERSION_WEBGL: js.Number = ???
-  def BROWSER_DEFAULT_WEBGL: js.Number = ???    
+  val UNPACK_FLIP_Y_WEBGL = 0x9240
+  val UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241
+  val CONTEXT_LOST_WEBGL = 0x9242
+  val UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243
+  val BROWSER_DEFAULT_WEBGL = 0x9244
 }
 
 class WebGLRenderingContext extends js.Object {
   /* ClearBufferMask */
-  var canvas: HTMLCanvasElement = ???
-  var drawingBufferWidth: js.Number = ???
-  var drawingBufferHeight: js.Number = ???
+  val canvas: HTMLCanvasElement = ???
+  val drawingBufferWidth: js.Number = ???
+  val drawingBufferHeight: js.Number = ???
   
   def getContextAttributes(): WebGLContextAttributes = ???
   def isContextLost(): js.Boolean = ???
@@ -417,7 +489,6 @@ class WebGLRenderingContext extends js.Object {
   def bufferData(target: js.Number, size: ArrayBufferView, usage: js.Number): Unit = ???
   def bufferData(target: js.Number, size: ArrayBuffer, usage: js.Number): Unit = ???
 
-  // WebGLHandlesContextLoss
   def checkFramebufferStatus(target: js.Number): js.Number = ???
   def clear(mask: js.Number): Unit = ???
   def clearColor(red: js.Number, green: js.Number, blue: js.Number, alpha: js.Number): Unit = ???
@@ -498,7 +569,6 @@ class WebGLRenderingContext extends js.Object {
   
   def hint(target: js.Number, mode: js.Number): js.Any = ???
   
-  // TODO: these are weird.
   def isBuffer(buffer: js.Any): js.Boolean = ???
   def isEnabled(cap: js.Number): js.Boolean = ???
   def isFramebuffer(framebuffer: js.Any): js.Boolean = ???


### PR DESCRIPTION
As a follow up to #12, here is a first stab at implementing the WebGL specification.  It should be complete, but I've not exercised it much yet, so it may contain bugs and typos.

trait TypedArrayCommon[T] is used to prevent (even more) code duplication, but perhaps it should be somehow tucked away out of sight since it's not defined anywhere in the spec.

I would add documentation but I don't have anything to scrape MDN and pop it into the code, does anyone have something that does this, or at least reduces some of the work?

Comments/suggestions/style warnings all gratefully received.
