### PR TITLE
Added the missing Touch class

### DIFF
--- a/src/main/scala/org/scalajs/dom/extensions/package.scala
+++ b/src/main/scala/org/scalajs/dom/extensions/package.scala
@@ -8,7 +8,7 @@ package object extensions {
 
   implicit class PimpedNodeList(nodes: dom.NodeList) extends EasySeq[dom.Node](nodes.length, nodes.apply)
 
-  implicit class PimpedTouchList(nodes: dom.TouchList) extends EasySeq[dom.TouchEvent](nodes.length, nodes.apply)
+  implicit class PimpedTouchList(nodes: dom.TouchList) extends EasySeq[dom.Touch](nodes.length, nodes.apply)
 
   implicit class PimpedHtmlCollection(coll: dom.HTMLCollection) extends EasySeq[dom.Element](coll.length, coll.apply)
 

--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -2195,15 +2195,137 @@ class TouchList extends js.Object {
    *
    * MDN
    */
-  def item(index: js.Number): TouchEvent = ???
+  def item(index: js.Number): Touch = ???
 
   @scala.scalajs.js.annotation.JSBracketAccess
-  def apply(index: js.Number): TouchEvent = ???
+  def apply(index: js.Number): Touch = ???
 
   @scala.scalajs.js.annotation.JSBracketAccess
   def update(index: js.Number, v: Node): Unit = ???
 }
 
+/**
+ * A Touch object represents a single point of contact between the user and a touch-sensitive
+ * interface device (which may be, for example, a touchscreen or a trackpad).
+ *
+ * Note: Many of these values are hardware-dependent; for example, if the device doesn't have a
+ * way to detect the amount of pressure placed on the surface, the force value will always be 1.0.
+ * This may also be the case for radiusX and radiusY; if the hardware reports only a single point,
+ * these values will be 1.
+ *
+ * MDN
+ */
+class Touch extends js.Object {
+
+  /**
+   * A unique identifier for this Touch object. A given touch (say, by a finger) will have the same
+   * identifier for the duration of its movement around the surface. This lets you ensure that you're
+   * tracking the same touch all the time. Read only.
+   *
+   * MDN
+   */
+  def identifier: js.Number = ???
+
+  /**
+   * The X coordinate of the touch point relative to the left edge of the screen.
+   * Read only.
+   *
+   * MDN
+   */
+  def screenX: js.Number = ???
+
+  /**
+   * The Y coordinate of the touch point relative to the top edge of the screen.
+   * Read only.
+   *
+   * MDN
+   */
+  def screenY: js.Number = ???
+
+  /**
+   * The X coordinate of the touch point relative to the left edge of the browser viewport,
+   * not including any scroll offset. Read only.
+   *
+   * MDN
+   */
+  def clientX: js.Number = ???
+
+  /**
+   * The Y coordinate of the touch point relative to the top edge of the browser viewport,
+   * not including any scroll offset. Read only.
+   *
+   * MDN
+   */
+  def clientY: js.Number = ???
+
+  /**
+   *  The X coordinate of the touch point relative to the left edge of the document. Unlike clientX,
+   *  this value includes the horizontal scroll offset, if any.
+   *
+   * MDN
+   *  Read only.
+   */
+  def pageX: js.Number = ???
+
+  /**
+   * The Y coordinate of the touch point relative to the top of the document. Unlike clientY, this value
+   * includes the vertical scroll offset, if any.
+   * Read only.
+   *
+   * MDN
+   */
+  def pageY: js.Number = ???
+
+  /**
+   * The X radius of the ellipse that most closely circumscribes the area of contact with the screen.
+   * The value is in pixels of the same scale as screenX.
+   * Read only.
+   *
+   * MDN
+   */
+  def radiusX: js.Number = ???
+
+  /**
+   * The Y radius of the ellipse that most closely circumscribes the area of contact with the screen.
+   * The value is in pixels of the same scale as screenY.
+   * Read only.
+   *
+   * MDN
+   */
+  def radiusY: js.Number = ???
+
+  /**
+   * The angle (in degrees) that the ellipse described by radiusX and radiusY must be rotated,
+   * clockwise, to most accurately cover the area of contact between the user and the surface.
+   * Read only.
+   *
+   * MDN
+   */
+  def rotationAngle: js.Number = ???
+
+  /**
+   * The amount of pressure being applied to the surface by the user, as a float
+   * between 0.0 (no pressure) and 1.0 (maximum pressure).
+   * Read only.
+   *
+   * MDN
+   */
+  def force: js.Number = ???
+
+  /**
+   * The Element on which the touch point started when it was first placed on the surface,
+   * even if the touch point has since moved outside the interactive area of that element or
+   * even been removed from the document. Note that if the target is removed from the document,
+   * events will still be targeted at it, and hence won't necessarily bubble up to the window
+   * or document anymore. If there's any risk of an element being removed while it is being
+   * touched, best practice is to attach the touch listeners directly to the target.
+   * Read only.
+   *
+   * MDN
+   */
+  def target: EventTarget = ???
+
+}
 /**
  * KeyboardEvent objects describe a user interaction with the keyboard. Each event
  * describes a key; the event type (keydown, keypress, or keyup) identifies what


### PR DESCRIPTION
The TouchList contains TouchEvent in stead of Touch objects as described in the spec. https://developer.mozilla.org/en-US/docs/Web/API/TouchList.

I have added the missing class and changed the wrong References. Don't mind my changes in the build files. I could not exclude them from the pull request. 

It is tested it for Android. See https://build.phonegap.com/apps/924534/share
and the code in https://github.com/wwagner4/doctus/blob/master/scalajs/src/main/scala/doctus/scalajs/DoctusScalajs.scala Line 133ff and https://github.com/wwagner4/doctus/blob/master/scalajs-showcase/src/main/scala/doctus/scalajs/Showcase.scala Line 38, 39
