### PR TITLE
Fix java.lang.ClassCastException in requestAnimationFrame

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -2054,7 +2054,7 @@ class Window extends EventTarget with WindowLocalStorage with WindowSessionStora
    *
    * MDN
    */
-  def requestAnimationFrame(callback: js.Function1[Int, _]): Int = ???
+  def requestAnimationFrame(callback: js.Function1[Double, _]): Int = ???
 }
 
 


### PR DESCRIPTION
The parameter to a FrameRequestCallback is not an Int, but a `DOMHighResTimeStamp`

http://www.w3.org/TR/hr-time/#domhighrestimestamp

```
A DOMHighResTimeStamp SHOULD represent a number of milliseconds accurate to a thousandth of a millisecond.
```

So (at least in Chrome), a java.lang.ClassCastException is thrown immediately upon entry, since the input is rarely an integer.  This should fix that.
