### PR TITLE
Change TextMetrics.width to be Double

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -1208,7 +1208,7 @@ class TextMetrics extends js.Object {
    *
    * MDN
    */
-  var width: Int = ???
+  var width: Double = ???
 }
 
 


### PR DESCRIPTION
Everything's blowing up on mobile devices! (Safari iPad3, Firefox/Chrome on Android).  The MDN spec in the comment above specifies that this should be a Double ;)

Seems desktops luckily set TextMetrics.width to an integer, but on mobile devices this is not so certain, so I hadn't noticed until just now.
