### PR TITLE
Honor timeout parameter in extensions.Ajax.apply

### DIFF
--- a/src/main/scala/org/scalajs/dom/extensions/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/extensions/Extensions.scala
@@ -191,6 +191,7 @@ object Ajax{
       }
     }
     req.open(method, url)
+    req.timeout = timeout
     req.withCredentials = withCredentials
     headers.foreach(x => req.setRequestHeader(x._1, x._2))
     req.send(data)


### PR DESCRIPTION
Apparently, the `timeout` parameter for `extensions.Ajax.apply` is ignored.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#Example.3A_using_a_timeout

When timeout occurs, `req` would be `readyState == 4 // DONE` and `status == 0`, so `apply` returns `Failure(AjaxException(req))`.
