### PR TITLE
added put,delete method, added X-Request-With header

### DIFF
--- a/src/main/scala/org/scalajs/dom/extensions/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/extensions/Extensions.scala
@@ -162,28 +162,28 @@ object Ajax{
   def get(url: String,
           data: String = "",
           timeout: Int = 0,
-          headers: Set[(String, String)] = Set.empty,
+          headers: Map[String, String] = Map.empty,
           withCredentials: Boolean = false) = {
     apply("GET", url, data, timeout, headers, withCredentials)
   }
   def post(url: String,
            data: String = "",
            timeout: Int = 0,
-           headers: Set[(String, String)] = Set.empty,
+           headers: Map[String, String] = Map.empty,
            withCredentials: Boolean = false) = {
     apply("POST", url, data, timeout, headers, withCredentials)
   }
   def put(url: String,
              data: String = "",
              timeout: Int = 0,
-             headers: Set[(String, String)] = Set.empty,
+             headers: Map[String, String] = Map.empty,
              withCredentials: Boolean = false) = {
     apply("PUT", url, data, timeout, headers, withCredentials)
   }
   def delete(url: String,
              data: String = "",
              timeout: Int = 0,
-             headers: Set[(String, String)] = Set.empty,
+             headers: Map[String, String] = Map.empty,
              withCredentials: Boolean = false) = {
     apply("DELETE", url, data, timeout, headers, withCredentials)
   }
@@ -191,9 +191,9 @@ object Ajax{
             url: String,
             data: String,
             timeout: Int,
-            headers: Set[(String, String)],
+            headers: Map[String, String],
             withCredentials: Boolean): Future[dom.XMLHttpRequest] = {
-    val ajaxReq = Set("X-Requested-With"->"XMLHttpRequest")
+    val ajaxReq = Map("X-Requested-With"->"XMLHttpRequest")
     val req = new dom.XMLHttpRequest()
     val promise = Promise[dom.XMLHttpRequest]
 


### PR DESCRIPTION
I think headers should be Set instead of Seq.
Ajax request should include X-Requested-With header like other javascript frameworks do such as JQuery.
In Play! framework, if we setup the CSRF filter, we need to add either CSRF token to the request
or have X-Requested-With in the header. Otherwise the filter will return 403  
[http://www.playframework.com/documentation/2.2.x/ScalaCsrf]
I also added 2 more methods PUT and DELETE because they are pretty common in REST.
What do you think?
