### PR TITLE
I think FileReader in lib.scala is wrong

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -6780,16 +6780,6 @@ class FileReader() extends EventTarget {
    */
   def readAsText(blob: Blob, encoding: String = "UTF-8"): Unit = ???
 
-  /**
-   * The readAsText method is used to starts reading the contents of the specified Blob
-   * or File. When the read operation is finished, the readyState becomes DONE, and the
-   * loadend is triggered. At that time, the result attribute contains the contents of
-   * the file as a text string.
-   *
-   * MDN
-   */
-  def readAsText(blob: Blob): Unit = ???
-
 }
 
 object FileReader extends js.Object {


### PR DESCRIPTION
MDN reference
https://developer.mozilla.org/en-US/docs/Web/API/FileReader
W3C reference
http://www.w3.org/TR/FileAPI/#dfn-filereader

I also did use it here 
https://github.com/hussachai/play-scalajs/blob/master/scalajs/src/main/scala/example/ScalaJSFileUpload.scala

Thanks
