### PR TITLE
Remove incorrect fillRule parameter from context.fill()

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -2858,7 +2858,7 @@ class CanvasRenderingContext2D extends js.Object {
    *
    * MDN
    */
-  def fill(fillRule: String = ???): Unit = ???
+  def fill(): Unit = ???
 
   /**
    * Creates a new, blank ImageData object with the specified dimensions. All of the


### PR DESCRIPTION
context.fill() is parameterless, see eg:
https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D
http://www.w3.org/TR/2014/CR-2dcontext-20140821/#drawing-paths-to-the-canvas
