### PR TITLE
Element: Fix setAttribute()

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -751,7 +751,7 @@ class Element extends Node with NodeSelector with ParentNode {
    *
    * MSN
    */
-  def setAttribute(name: String = ???, value: String = ???): Unit = ???
+  def setAttribute(name: String, value: String): Unit = ???
 
   /**
    * removeAttributeNS removes the specified attribute from an element.


### PR DESCRIPTION
According to [^dom](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-F68F082) all parameters are required. Currently, it is
possible to skip the arguments without an error being issued during
compilation.
