### PR TITLE
Add charCode method binding to KeyboardEvent

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -2357,8 +2357,19 @@ class Touch extends js.Object {
  * text from hand-writing system like tablet PC, key events may not be fired.
  *
  * MDN
+ *
+ * Warning: keypress event is to be deprecated in favor of beforeinput event eventually
+ *
+ * W3C
  */
 class KeyboardEvent extends UIEvent with ModifierKeyEvent {
+  /**
+   * Returns the Unicode value of a character key pressed during a keypress event.
+   *
+   * Note: Required especially in Gecko based browsers
+   */
+  def charCode: Int = ???
+
   /**
    * A system and implementation dependent numerical code identifying the
    * unmodified value of the pressed key. This is usually the decimal ASCII


### PR DESCRIPTION
The thing is, that even though keypress event is to be deprecated in favor of [beforeinput](http://www.w3.org/TR/DOM-Level-3-Events/#event-type-keypress), it's still in far future.

Currently there is no way to get hold of keypress event unicode value in Gecko based browsers where you can find it with certainty in charCode only. (based on my todays investigations).

For further reading, please see this [google groups thread](https://groups.google.com/d/msg/scala-js/NFdMIbLLupE/VqQd3aeUntMJ)
