### PR TITLE
deprecate Node.isSameNode Node.isSupported. add missing Node.contains

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -943,7 +943,9 @@ class Node extends EventTarget {
    * The Node.isSupported()returns a Boolean flag containing the result of a test
    * whether the DOM implementation implements a specific feature and this feature is
    * supported by the specific node.
-   *
+   * @deprecated
+   * This feature is obsolete. Although it may still work in some browsers, its use
+   * is discouraged since it could be removed at any time. Try to avoid using it.
    * MDN
    */
   def isSupported(feature: String, version: String): Boolean = ???
@@ -991,6 +993,15 @@ class Node extends EventTarget {
   /**
    * Tests whether two nodes are the same, that is they reference the same object.
    *
+   * @deprecated
+   * {{{
+   * // Instead of using
+   * node1.isSameNode(node2)
+   *
+   * // use
+   * node1 === node2 // or
+   * node1 == node2
+   * }}}
    * MDN
    */
   def isSameNode(other: Node): Boolean = ???
@@ -1040,6 +1051,13 @@ class Node extends EventTarget {
    * MDN
    */
   def insertBefore(newChild: Node, refChild: Node = ???): Node = ???
+
+  /**
+   * @return a Boolean value indicating whether a node is a descendant of a given node. or not.
+   *
+   * MDN
+   */
+  def contains(otherNode: Node): Boolean = ???
 }
 
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Node.isSameNode
https://developer.mozilla.org/en-US/docs/Web/API/Node.isSupported
https://developer.mozilla.org/en-US/docs/Web/API/Node.contains