### PR TITLE
IDBKeyRange has static methods that should be defined in scala object

### DIFF
--- a/src/main/scala/org/scalajs/dom/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/Idb.scala
@@ -380,6 +380,9 @@ class IDBKeyRange extends js.Object {
    * MDN
    */
   def lowerOpen: Boolean = js.native
+}
+
+object IDBKeyRange extends js.Object {
   /**
    * The bounds can be open (that is, the bounds exclude the endpoint values) or closed
    * (that is, the bounds include the endpoint values). By default, the bounds are


### PR DESCRIPTION
[IDBKeyRange](http://www.w3.org/TR/IndexedDB/#idl-def-IDBKeyRange) should be like this right?

But currently it is just a class [IDBKeyRange](https://github.com/scala-js/scala-js-dom/blob/master/src/main/scala/org/scalajs/dom/Idb.scala#L355) and if you call 

``` scala
new IDBKeyRange().bound("a","z")
```

you'll get `TypeError: IDBKeyRangeConstructor is not a constructor (evaluating 'new ScalaJS.g["IDBKeyRange"]()')`

I tested the solution I suggested, doing : 

``` scala
IDBKeyRange.bound("a","z")
```

resolves to `IDBKeyRange` instance
