### PR TITLE
Missing IDBCursor#continue method binding

### DIFF
--- a/src/main/scala/org/scalajs/dom/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/Idb.scala
@@ -284,6 +284,16 @@ class IDBCursor extends js.Object {
   def advance(count: Int): Unit = js.native
 
   /**
+   * Sets cursor to key if specified, otherwise advances cursor by one.
+   *
+   * @note calling this method twice from the same onsuccess handler results
+   *       in a InvalidStateError DOMException being thrown on the second call
+   *
+   * W3C
+   */
+  def continue(key: js.Any = ???): Unit = js.native
+
+  /**
    * Returns an IDBRequest object, and, in a separate thread, deletes the record at the
    * cursor's position, without changing the cursor's position.
    *


### PR DESCRIPTION
Hi, please merge this one, it has been well tested. [w3c](http://www.w3.org/TR/IndexedDB/#cursor)
