### PR TITLE
HTMLSelectElement: Fix return type of ``options``

### DIFF
--- a/src/main/scala/org/scalajs/dom/Html.scala
+++ b/src/main/scala/org/scalajs/dom/Html.scala
@@ -855,7 +855,7 @@ class HTMLSelectElement extends HTMLElement {
    *
    * MDN
    */
-  val options: HTMLSelectElement = js.native
+  val options: js.Array[HTMLSelectElement] = js.native
   /**
    * The value of this form control, that is, of the first selected option.
    *


### PR DESCRIPTION
Currently, the i-th element cannot be accessed without resorting to
js.Dynamic.
