### PR TITLE
EventTarrget.addEventListener event subclass

### DIFF
--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -2235,7 +2235,7 @@ class EventTarget extends js.Object {
    *
    * MDN
    */
-  def addEventListener(`type`: String, listener: js.Function1[Event, _], useCapture: Boolean = js.native): Unit = js.native
+  def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean = js.native): Unit = js.native
 
   /**
    * Dispatches an Event at the specified EventTarget, invoking the affected


### PR DESCRIPTION
Currently it is not possible to use an event listener that takes a subclass of Event as a parameter.
This change enables any subclass of Event to be taken as a parameter of the listener.