### PR TITLE
IDBDatabase#version should be typed as Integer

### DIFF
--- a/src/main/scala/org/scalajs/dom/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/Idb.scala
@@ -544,12 +544,13 @@ object IDBTransaction extends js.Object {
  */
 class IDBDatabase extends EventTarget {
   /**
-   * A 64-bit integer that contains the version of the connected database. When a
-   * database is first created, this attribute is the empty string.
-   *
-   * MDN
+   * A 64-bit integer that contains the version of the connected database.
+   * When a database is first created or upgraded you should use
+   * [[org.scalajs.dom.IDBVersionChangeEvent#newVersion]] instead.
+   * Webkit returns always integer and the value is 1 when
+   * database is first created.
    */
-  def version: String = js.native
+  def version: Int = js.native
 
   /**
    * A DOMString that contains the name of the connected database.


### PR DESCRIPTION
Hi, from what I observed this is the correct typing for `IDBDatabase#version`. 

I haven't tested whether firefox still returns empty string when database is first created. It is not recommended though because within version upgrade callback one should be calling only `IDBVersionChangeEvent#newVersion` and `IDBVersionChangeEvent#oldVersion`.

Anyway webkits always return Integer, imho they have a fallback to `IDBVersionChangeEvent#newVersion` whereas firefox has/had fallback to empty string.

Either way `String` type doesn't make sense and I think that using `js.Any` just because Firefox might fall back to empty string is wrong. User of the API will know from scaladoc that he should use  `IDBVersionChangeEvent#newVersion` instead in that case.