### PR TITLE
Reorganize the org.scalajs.dom namespace into something saner

### DIFF
--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,9 +1,7 @@
 package example
 
-import scala.scalajs.js.JSApp
-
 import org.scalajs.dom
-
+import dom.html
 import scala.scalajs.js.annotation.JSExport
 
 @JSExport
@@ -18,7 +16,7 @@ object Alert {
 @JSExport
 object NodeAppendChild {
   @JSExport
-  def main(div: dom.HTMLDivElement) = {
+  def main(div: html.Div) = {
     val child = dom.document
                    .createElement("div")
 
@@ -32,7 +30,7 @@ object NodeAppendChild {
 @JSExport
 object ElementStyle {
   @JSExport
-  def main(div: dom.HTMLDivElement) = {
+  def main(div: html.Div) = {
     val colors = Seq(
       "red", "green", "blue"
     )
@@ -47,8 +45,7 @@ object ElementStyle {
 @JSExport
 object LocalStorage {
   @JSExport
-  def main(in: dom.HTMLInputElement,
-           box: dom.HTMLDivElement) = {
+  def main(in: html.Input, box: html.Div) = {
     val key = "my-key"
 
     in.value =
@@ -67,7 +64,7 @@ object LocalStorage {
 @JSExport
 object Canvas {
   @JSExport
-  def main(c: dom.HTMLCanvasElement) = {
+  def main(c: html.Canvas) = {
     type Ctx2D =
       dom.CanvasRenderingContext2D
     val ctx = c.getContext("2d")
@@ -93,8 +90,8 @@ object Canvas {
 @JSExport
 object Base64 {
   @JSExport
-  def main(in: dom.HTMLInputElement,
-           out: dom.HTMLDivElement) = {
+  def main(in: html.Input,
+           out: html.Div) = {
     in.onkeyup = { (e: dom.Event) =>
       out.textContent =
         dom.btoa(in.value)
@@ -105,7 +102,7 @@ object Base64 {
 @JSExport
 object EventHandler{
   @JSExport
-  def main(pre: dom.HTMLPreElement) = {
+  def main(pre: html.Pre) = {
     pre.onmousemove = {
       (e: dom.MouseEvent) =>
         pre.textContent =
@@ -123,7 +120,7 @@ object EventHandler{
 @JSExport
 object XMLHttpRequest{
   @JSExport
-  def main(pre: dom.HTMLPreElement) = {
+  def main(pre: html.Pre) = {
     val xhr = new dom.XMLHttpRequest()
     xhr.open("GET",
       "http://api.openweathermap.org/" +
@@ -142,8 +139,8 @@ object XMLHttpRequest{
 @JSExport
 object Websocket {
   @JSExport
-  def main(in: dom.HTMLInputElement,
-           pre: dom.HTMLPreElement) = {
+  def main(in: html.Input,
+           pre: html.Pre) = {
     val echo = "ws://echo.websocket.org"
     val socket = new dom.WebSocket(echo)
     socket.onmessage = {
@@ -162,8 +159,8 @@ object Websocket {
 @JSExport
 object AjaxExtension {
   @JSExport
-  def main(pre: dom.HTMLPreElement) = {
-    import dom.extensions.Ajax
+  def main(pre: html.Pre) = {
+    import dom.ext.Ajax
     import scalajs.concurrent
                   .JSExecutionContext
                   .Implicits

--- a/src/main/scala/org/scalajs/dom/css.scala
+++ b/src/main/scala/org/scalajs/dom/css.scala
@@ -1,0 +1,19 @@
+package org.scalajs.dom
+
+/**
+ * Short aliasas of all the dom.CSSThing classes
+ */
+object css {
+  type FontFaceRule = raw.CSSFontFaceRule
+  type ImportRule = raw.CSSImportRule
+  type KeyframeRule = raw.CSSKeyframeRule
+  type MediaRule = raw.CSSMediaRule
+  type NamespaceRule = raw.CSSNamespaceRule
+  type PageRule = raw.CSSPageRule
+  type Rule = raw.CSSRule
+  @inline def Rule = raw.CSSRule
+  type RuleList = raw.CSSRuleList
+  type StyleDeclaration = raw.CSSStyleDeclaration
+  type StyleSheet = raw.CSSStyleSheet
+  type StyleRule = raw.CSSStyleRule
+}

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -1,4 +1,6 @@
-package org.scalajs.dom.extensions
+package org.scalajs.dom.ext
+
+import org.scalajs.dom.html
 
 import scala.scalajs.js
 import org.scalajs.dom
@@ -80,7 +82,7 @@ object Image {
     val img =
       dom.document
         .createElement("img")
-        .asInstanceOf[dom.HTMLImageElement]
+        .asInstanceOf[html.Image]
 
     img.src = "data:image/svg+xml;base64," + s
     img
@@ -199,7 +201,7 @@ object Ajax{
             withCredentials: Boolean, 
             responseType: String): Future[dom.XMLHttpRequest] = {
     val req = new dom.XMLHttpRequest()
-    val promise = Promise[dom.XMLHttpRequest]
+    val promise = Promise[dom.XMLHttpRequest]()
 
     req.onreadystatechange = {(e: dom.Event) =>
       if (req.readyState.toInt == 4){

--- a/src/main/scala/org/scalajs/dom/ext/KeyValue.scala
+++ b/src/main/scala/org/scalajs/dom/ext/KeyValue.scala
@@ -1,4 +1,4 @@
-package org.scalajs.dom.extensions
+package org.scalajs.dom.ext
 
 /**
  * The KeyboardEvent.key attribute of an event must always contain one of these control key or character values (even if

--- a/src/main/scala/org/scalajs/dom/ext/package.scala
+++ b/src/main/scala/org/scalajs/dom/ext/package.scala
@@ -2,31 +2,29 @@ package org.scalajs.dom
 
 import scala.language.implicitConversions
 
-import scala.scalajs.js
-import org.scalajs.dom
 import scala.collection.mutable
 
-package object extensions {
+package object ext {
 
-  implicit class PimpedNodeList(nodes: dom.NodeList) extends EasySeq[dom.Node](nodes.length, nodes.apply)
+  implicit class PimpedNodeList(nodes: NodeList) extends EasySeq[Node](nodes.length, nodes.apply)
 
-  implicit class PimpedTouchList(nodes: dom.TouchList) extends EasySeq[dom.Touch](nodes.length, nodes.apply)
+  implicit class PimpedTouchList(nodes: TouchList) extends EasySeq[Touch](nodes.length, nodes.apply)
 
-  implicit class PimpedHtmlCollection(coll: dom.HTMLCollection) extends EasySeq[dom.Element](coll.length, coll.apply)
+  implicit class PimpedHtmlCollection(coll: html.Collection) extends EasySeq[Element](coll.length, coll.apply)
 
-  implicit class PimpedSVGTransformList(coll: dom.SVGTransformList) extends EasySeq[dom.SVGTransform](coll.numberOfItems, coll.getItem)
+  implicit class PimpedSVGTransformList(coll: svg.TransformList) extends EasySeq[svg.Transform](coll.numberOfItems, coll.getItem)
 
   implicit class Castable(x: Any) {
     def cast[T] = x.asInstanceOf[T]
   }
 
-  implicit def pimpAnimatedNumber(x: dom.SVGAnimatedNumber) = x.baseVal
+  implicit def pimpAnimatedNumber(x: svg.AnimatedNumber) = x.baseVal
 
-  implicit def pimpRichAnimatedNumber(x: dom.SVGAnimatedNumber) = x.baseVal: runtime.RichDouble
+  implicit def pimpRichAnimatedNumber(x: svg.AnimatedNumber) = x.baseVal: runtime.RichDouble
 
-  implicit def pimpAnimatedLength(x: dom.SVGAnimatedLength) = x.baseVal.value
+  implicit def pimpAnimatedLength(x: svg.AnimatedLength) = x.baseVal.value
 
-  implicit def pimpRichAnimatedLength(x: dom.SVGAnimatedLength) = x.baseVal.value: runtime.RichDouble
+  implicit def pimpRichAnimatedLength(x: svg.AnimatedLength) = x.baseVal.value: runtime.RichDouble
 
   implicit def color2String(c: Color) = c.toString
   implicit class pimpedContext(val ctx: CanvasRenderingContext2D) {
@@ -69,7 +67,6 @@ package object extensions {
     }
   }
 
-
   /**
    * Implicit class to deal with attributes as with normal mutable Map
    * @param attributes
@@ -80,7 +77,6 @@ package object extensions {
     override def iterator: Iterator[(String, Attr)] = new Iterator[(String, Attr)] {
       var index = 0
 
-
       override def next(): (String, Attr) = {
         val n: Attr = attributes.item(index)
         this.index = this.index + 1
@@ -90,14 +86,12 @@ package object extensions {
       override def hasNext: Boolean = index < self.length
     }
 
-
     override def get(key: String): Option[Attr] = attributes.getNamedItem(key) match {
       case null => None
       case attr => Some(attr)
     }
 
     def length: Int = attributes.length.toInt
-
 
     override def -=(key: String) = {
       attributes.removeNamedItem(key)
@@ -108,6 +102,4 @@ package object extensions {
       attributes.setNamedItem(kv._2)
       this}
   }
-
-
 }

--- a/src/main/scala/org/scalajs/dom/html.scala
+++ b/src/main/scala/org/scalajs/dom/html.scala
@@ -1,0 +1,85 @@
+package org.scalajs.dom
+
+/**
+ * Short aliasas of all the dom.HTMLThing classes
+ */
+object html {
+  type Anchor = raw.HTMLAnchorElement
+  type Applet = raw.HTMLAppletElement
+  type Audio = raw.HTMLAudioElement
+  type Area = raw.HTMLAreaElement
+  type AreasCollection = raw.HTMLAreasCollection
+  type Base = raw.HTMLBaseElement
+  type BaseFont = raw.HTMLBaseFontElement
+  type BGSound = raw.HTMLBGSoundElement
+  type BlockElement = raw.HTMLBlockElement
+  type Body = raw.HTMLBodyElement
+  type Button = raw.HTMLButtonElement
+  type BR = raw.HTMLBRElement
+  type Canvas = raw.HTMLCanvasElement
+  type Collection = raw.HTMLCollection
+  type DataList = raw.HTMLDataListElement
+  type DD = raw.HTMLDDElement
+  type Directory = raw.HTMLDirectoryElement
+  type Div = raw.HTMLDivElement
+  type DList = raw.HTMLDListElement
+  type DT = raw.HTMLDTElement
+  type Document = raw.HTMLDocument
+  type Element = raw.HTMLElement
+  type Embed = raw.HTMLEmbedElement
+  type FieldSet = raw.HTMLFieldSetElement
+  type Font = raw.HTMLFontElement
+  type Form = raw.HTMLFormElement
+  type Frame = raw.HTMLFrameElement
+  type FrameSet = raw.HTMLFrameSetElement
+  type Head = raw.HTMLHeadElement
+  type Heading = raw.HTMLHeadingElement
+  type Html = raw.HTMLHtmlElement
+  type HR = raw.HTMLHRElement
+  type IFrame = raw.HTMLIFrameElement
+  type Image = raw.HTMLImageElement
+  type Input = raw.HTMLInputElement
+  type IsIndex = raw.HTMLIsIndexElement
+  type Label = raw.HTMLLabelElement
+  type Legend = raw.HTMLLegendElement
+  type LI = raw.HTMLLIElement
+  type Link = raw.HTMLLinkElement
+  type Map = raw.HTMLMapElement
+  type Marquee = raw.HTMLMarqueeElement
+  type Media = raw.HTMLMediaElement
+  @inline def Media = raw.HTMLMediaElement
+  type Menu = raw.HTMLMenuElement
+  type Meta = raw.HTMLMetaElement
+  type Mod = raw.HTMLModElement
+  type NextIdElement = raw.HTMLNextIdElement
+  type Object = raw.HTMLObjectElement
+  type OList = raw.HTMLOListElement
+  type OptGroup = raw.HTMLOptGroupElement
+  type Option = raw.HTMLOptionElement
+  type Paragraph = raw.HTMLParagraphElement
+  type Param = raw.HTMLParamElement
+  type Pre = raw.HTMLPreElement
+  type Phrase = raw.HTMLPhraseElement
+  type Progress = raw.HTMLProgressElement
+  type Quote = raw.HTMLQuoteElement
+  type Script = raw.HTMLScriptElement
+  type Select = raw.HTMLSelectElement
+  type Source = raw.HTMLSourceElement
+  type Span = raw.HTMLSpanElement
+  type Style = raw.HTMLStyleElement
+  type Table = raw.HTMLTableElement
+  type TableAlignment = raw.HTMLTableAlignment
+  type TableCaption = raw.HTMLTableCaptionElement
+  type TableCell = raw.HTMLTableCellElement
+  type TableCol = raw.HTMLTableColElement
+  type TableDataCell = raw.HTMLTableDataCellElement
+  type TableHeaderCell = raw.HTMLTableHeaderCellElement
+  type TableRow = raw.HTMLTableRowElement
+  type TableSection = raw.HTMLTableSectionElement
+  type Title = raw.HTMLTitleElement
+  type TextArea = raw.HTMLTextAreaElement
+  type Track = raw.HTMLTrackElement
+  type UList = raw.HTMLUListElement
+  type Unknown = raw.HTMLUnknownElement
+  type Video = raw.HTMLVideoElement
+}

--- a/src/main/scala/org/scalajs/dom/idb.scala
+++ b/src/main/scala/org/scalajs/dom/idb.scala
@@ -1,0 +1,22 @@
+package org.scalajs.dom
+
+/**
+ * Short aliasas of all the dom.IDBThing classes
+ */
+object idb {
+  type Cursor = raw.IDBCursor
+  @inline def Cursor = raw.IDBCursor
+  type CursorWithValue = raw.IDBCursorWithValue
+  type Database = raw.IDBDatabase
+  type Environment = raw.IDBEnvironment
+  type Factory = raw.IDBFactory
+  type Index = raw.IDBIndex
+  type KeyRange = raw.IDBKeyRange
+  @inline def KeyRange = raw.IDBKeyRange
+  type ObjectStore = raw.IDBObjectStore
+  type OpenDBRequest = raw.IDBOpenDBRequest
+  type Request = raw.IDBRequest
+  type Transaction = raw.IDBTransaction
+  @inline def Transaction = raw.IDBTransaction
+  type VersionChangeEvent = raw.IDBVersionChangeEvent
+}

--- a/src/main/scala/org/scalajs/dom/package.scala
+++ b/src/main/scala/org/scalajs/dom/package.scala
@@ -1,3 +1,189 @@
 package org.scalajs
 
-package object dom extends dom.Window with scalajs.js.GlobalScope
+import org.scalajs.dom.raw.Window
+import scala.scalajs.js
+
+package object dom extends Window with scalajs.js.GlobalScope {
+  type AbstractWorker = raw.AbstractWorker
+  type AnimationEvent = raw.AnimationEvent
+  type ApplicationCache = raw.ApplicationCache
+  val ApplicationCache: raw.ApplicationCache.type = js.native
+  type Attr = raw.Attr
+  type AudioTrack = raw.AudioTrack
+  type AudioTrackList = raw.AudioTrackList
+
+  type BeforeUnloadEvent = raw.BeforeUnloadEvent
+  type Blob = raw.Blob
+  val Blob: raw.Blob.type = js.native
+  type BlobPropertyBag = raw.BlobPropertyBag
+
+  type CanvasGradient = raw.CanvasGradient
+  type CanvasPattern = raw.CanvasPattern
+  type CanvasRenderingContext2D = raw.CanvasRenderingContext2D
+  type CDATASection = raw.CDATASection
+  type CharacterData = raw.CharacterData
+  type ClientRect = raw.ClientRect
+  type ClientRectList = raw.ClientRectList
+  type CloseEvent = raw.CloseEvent
+  type CompositionEvent = raw.CompositionEvent
+  type Comment = raw.Comment
+  type Coordinates = raw.Coordinates
+  type Console = raw.Console
+  type CustomEvent = raw.CustomEvent
+
+  type DataTransfer = raw.DataTransfer
+  type DocumentType = raw.DocumentType
+  type DocumentEvent = raw.DocumentEvent
+  type Document = raw.Document
+  type DocumentFragment = raw.DocumentFragment
+  type DOMException = raw.DOMException
+  type DOMImplementation = raw.DOMImplementation
+  val DOMException: raw.DOMException.type = js.native
+  type DOMError = raw.DOMError
+  type DOMList[T] = raw.DOMList[T]
+  type DOMParser = raw.DOMParser
+  type DOMSettableTokenList = raw.DOMSettableTokenList
+  type DOMStringList = raw.DOMStringList
+  type DOMTokenList = raw.DOMTokenList
+  type DragEvent = raw.DragEvent
+
+  type Element = raw.Element
+  type ErrorEvent = raw.ErrorEvent
+  type Event = raw.Event
+  val Event: raw.Event.type = js.native
+  type EventException = raw.EventException
+  val EventException: raw.EventException.type = js.native
+  type EventSource = raw.EventSource
+  val EventSource: raw.EventSource.type = js.native
+  type EventTarget = raw.EventTarget
+  type External = raw.External
+
+  type FocusEvent = raw.FocusEvent
+  type File = raw.File
+  type FileList = raw.FileList
+  type FileReader = raw.FileReader
+  val FileReader: raw.FileReader.type = js.native
+  type FormData = raw.FormData
+  val FormData: raw.FormData.type = js.native
+
+  type Geolocation = raw.Geolocation
+
+  type HashChangeEvent = raw.HashChangeEvent
+  type History = raw.History
+
+  type ImageData = raw.ImageData
+
+  type KeyboardEvent = raw.KeyboardEvent
+  val KeyboardEvent: raw.KeyboardEvent.type = js.native
+
+  type LinkStyle = raw.LinkStyle
+  type Location = raw.Location
+
+  type MediaError = raw.MediaError
+  val MediaError: raw.MediaError.type = js.native
+  type MediaList = raw.MediaList
+  type MediaQueryList = raw.MediaQueryList
+  type MediaQueryListListener = raw.MediaQueryListListener
+  type MessageChannel = raw.MessageChannel
+  type MessageEvent = raw.MessageEvent
+  type MessagePort = raw.MessagePort
+  type ModifierKeyEvent = raw.ModifierKeyEvent
+  type MouseEvent = raw.MouseEvent
+  type MutationEvent = raw.MutationEvent
+  val MutationEvent: raw.MutationEvent.type = js.native
+  type MutationObserver = raw.MutationObserver
+  type MutationObserverInit = raw.MutationObserverInit
+  val MutationObserverInit: raw.MutationObserverInit.type = js.native
+  type MutationRecord = raw.MutationRecord
+
+  type NamedNodeMap = raw.NamedNodeMap
+  type NavigatorID = raw.NavigatorID
+  type Navigator = raw.Navigator
+  type NavigatorGeolocation = raw.NavigatorGeolocation
+  type NavigatorContentUtils = raw.NavigatorContentUtils
+  type NavigatorOnLine = raw.NavigatorOnLine
+  type NavigatorStorageUtils = raw.NavigatorStorageUtils
+  type NodeSelector = raw.NodeSelector
+  type Node = raw.Node
+  val Node: raw.Node.type = js.native
+  type NodeFilter = raw.NodeFilter
+  val NodeFilter: raw.NodeFilter.type = js.native
+  type NodeIterator = raw.NodeIterator
+  type NodeList = raw.NodeList
+  type NodeListOf[TNode <: Node] = raw.NodeListOf[TNode]
+
+  type ObjectURLOptions = raw.ObjectURLOptions
+
+  type ParentNode = raw.ParentNode
+  type Performance = raw.Performance
+  type PerformanceEntry = raw.PerformanceEntry
+  type PerformanceTiming = raw.PerformanceTiming
+  type PerformanceMark = raw.PerformanceMark
+  type PerformanceMeasure = raw.PerformanceMeasure
+  type PerformanceNavigation = raw.PerformanceNavigation
+  val PerformanceNavigation: raw.PerformanceNavigation.type = js.native
+  type PerformanceResourceTiming = raw.PerformanceResourceTiming
+  type Position = raw.Position
+  type PositionOptions = raw.PositionOptions
+  type PositionError = raw.PositionError
+  val PositionError: raw.PositionError.type = js.native
+  type ProcessingInstruction = raw.ProcessingInstruction
+  type ProgressEvent = raw.ProgressEvent
+  type PopStateEvent = raw.PopStateEvent
+
+  type Range = raw.Range
+  val Range: raw.Range.type = js.native
+
+  type Screen = raw.Screen
+  type Selection = raw.Selection
+  type Storage = raw.Storage
+  type StorageEvent = raw.StorageEvent
+  type StyleMedia = raw.StyleMedia
+  type StyleSheetList = raw.StyleSheetList
+  type StyleSheet = raw.StyleSheet
+
+  type Text = raw.Text
+  type TextEvent = raw.TextEvent
+  val TextEvent: raw.TextEvent.type = js.native
+  type TextMetrics = raw.TextMetrics
+  type TextTrack = raw.TextTrack
+  val TextTrack: raw.TextTrack.type = js.native
+  type TextTrackCue = raw.TextTrackCue
+  type TextTrackCueList = raw.TextTrackCueList
+  type TextTrackList = raw.TextTrackList
+  type TimeRanges = raw.TimeRanges
+  type Touch = raw.Touch
+  type TouchEvent = raw.TouchEvent
+  type TouchList = raw.TouchList
+  type TrackEvent = raw.TrackEvent
+  type TransitionEvent = raw.TransitionEvent
+  type TreeWalker = raw.TreeWalker
+
+  type UIEvent = raw.UIEvent
+  type URL = raw.URL
+
+  type ValidityState = raw.ValidityState
+
+  type WebSocket = raw.WebSocket
+  val WebSocket: raw.WebSocket.type = js.native
+  type WheelEvent = raw.WheelEvent
+  val WheelEvent: raw.WheelEvent.type = js.native
+  type Window = raw.Window
+  type WindowConsole = raw.WindowConsole
+  type WindowLocalStorage = raw.WindowLocalStorage
+  type WindowSessionStorage = raw.WindowSessionStorage
+  type WindowTimers = raw.WindowTimers
+  type WindowTimersExtension = raw.WindowTimersExtension
+
+  type WindowBase64 = raw.WindowBase64
+  type Worker = raw.Worker
+  val Worker: raw.Worker.type = js.native
+
+  type XMLHttpRequest = raw.XMLHttpRequest
+  val XMLHttpRequest: raw.XMLHttpRequest.type = js.native
+  type XMLHttpRequestEventTarget = raw.XMLHttpRequestEventTarget
+  type XMLSerializer = raw.XMLSerializer
+  type XPathResult = raw.XPathResult
+  val XPathResult: raw.XPathResult.type = js.native
+  type XPathNSResolver = raw.XPathNSResolver
+}

--- a/src/main/scala/org/scalajs/dom/raw/Css.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Css.scala
@@ -8,7 +8,7 @@
  * http://opensource.org/licenses/MIT
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
 
 import scala.scalajs.js
 

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -8,7 +8,7 @@
  * http://opensource.org/licenses/MIT
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
 
 import scala.scalajs.js
 

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -8,7 +8,9 @@
  * http://opensource.org/licenses/MIT
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
+
+import org.scalajs.dom
 
 import scala.scalajs.js
 
@@ -546,7 +548,7 @@ class IDBDatabase extends EventTarget {
   /**
    * A 64-bit integer that contains the version of the connected database.
    * When a database is first created or upgraded you should use
-   * [[org.scalajs.dom.IDBVersionChangeEvent#newVersion]] instead.
+   * [[dom.idb.VersionChangeEvent#newVersion]] instead.
    * Webkit returns always integer and the value is 1 when
    * database is first created.
    */

--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -8,7 +8,7 @@
  * http://opensource.org/licenses/MIT
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
 
 import scala.scalajs.js
 

--- a/src/main/scala/org/scalajs/dom/raw/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebGL.scala
@@ -4,11 +4,10 @@
  * Based on https://www.khronos.org/registry/webgl/specs/1.0/
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
 
 import scala.scalajs.js
-import js.annotation._
-import js.typedarray._
+import scala.scalajs.js.typedarray._
 
 /**
  * Contains drawing surface attributes.

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -8,10 +8,9 @@
  * http://opensource.org/licenses/MIT
  */
 
-package org.scalajs.dom
+package org.scalajs.dom.raw
 
 import scala.scalajs.js
-import scala.scalajs.js.Dynamic.global
 
 object XPathResult extends js.Object {
 

--- a/src/main/scala/org/scalajs/dom/svg.scala
+++ b/src/main/scala/org/scalajs/dom/svg.scala
@@ -1,0 +1,169 @@
+package org.scalajs.dom
+
+/**
+ * Short aliasas of all the dom.SVGThing classes
+ */
+object svg {
+  type A = raw.SVGAElement
+  type AnimatedAngle = raw.SVGAnimatedAngle
+  type AnimatedBoolean = raw.SVGAnimatedBoolean
+  type AnimatedInteger = raw.SVGAnimatedInteger
+  type AnimatedEnumeration = raw.SVGAnimatedEnumeration
+  type AnimatedPreserveAspectRatio = raw.SVGAnimatedPreserveAspectRatio
+  type AnimatedLength = raw.SVGAnimatedLength
+  type AnimatedLengthList = raw.SVGAnimatedLengthList
+  type AnimatedNumber = raw.SVGAnimatedNumber
+  type AnimatedNumberList = raw.SVGAnimatedNumberList
+  type AnimatedPathData = raw.SVGAnimatedPathData
+  type AnimatedPoints = raw.SVGAnimatedPoints
+  type AnimatedRect = raw.SVGAnimatedRect
+  type AnimatedString = raw.SVGAnimatedString
+  type AnimatedTransformList = raw.SVGAnimatedTransformList
+  type Angle = raw.SVGAngle
+  @inline def Angle = raw.SVGAngle
+
+  type Circle = raw.SVGCircleElement
+  type ClipPath = raw.SVGClipPathElement
+  type ComponentTransferFunction = raw.SVGComponentTransferFunctionElement
+  @inline def ComponentTransferFunction = raw.SVGComponentTransferFunctionElement
+
+  type Defs = raw.SVGDefsElement
+  type Desc = raw.SVGDescElement
+
+  type Element = raw.SVGElement
+  type ElementInstance = raw.SVGElementInstance
+  type ElementInstanceList = raw.SVGElementInstanceList
+  type Ellipse = raw.SVGEllipseElement
+  type Exception = raw.SVGException
+  @inline def Exception = raw.SVGException
+  type ExternalResourcesRequired = raw.SVGExternalResourcesRequired
+
+  type FEBlend = raw.SVGFEBlendElement
+  @inline def FEBlend = raw.SVGFEBlendElement
+  type FEColorMatrix = raw.SVGFEColorMatrixElement
+  @inline def FEColorMatrix = raw.SVGFEColorMatrixElement
+  type FEComposite = raw.SVGFECompositeElement
+  @inline def FEComposite = raw.SVGFECompositeElement
+  type FEComponentTransfer = raw.SVGFEComponentTransferElement
+  type FEConvolveMatrix = raw.SVGFEConvolveMatrixElement
+  @inline def FEConvolveMatrix = raw.SVGFEConvolveMatrixElement
+  type FEDistantLight = raw.SVGFEDistantLightElement
+  type FEDiffuseLighting = raw.SVGFEDiffuseLightingElement
+  type FEDisplacementMap = raw.SVGFEDisplacementMapElement
+  @inline def FEDisplacementMap = raw.SVGFEDisplacementMapElement
+  type FEFlood = raw.SVGFEFloodElement
+  type FEFuncA = raw.SVGFEFuncAElement
+  type FEFuncB = raw.SVGFEFuncBElement
+  type FEFuncG = raw.SVGFEFuncGElement
+  type FEFuncR = raw.SVGFEFuncRElement
+  type FEGaussianBlur = raw.SVGFEGaussianBlurElement
+  type FEImage = raw.SVGFEImageElement
+  type FEMerge = raw.SVGFEMergeElement
+  type FEMergeNode = raw.SVGFEMergeNodeElement
+  type FEMorphology = raw.SVGFEMorphologyElement
+  type FEOffset = raw.SVGFEOffsetElement
+  type FEPointLight = raw.SVGFEPointLightElement
+  type FESpecularLighting = raw.SVGFESpecularLightingElement
+  @inline def FEMorphology = raw.SVGFEMorphologyElement
+  type FESpotLight = raw.SVGFESpotLightElement
+  type FETile = raw.SVGFETileElement
+  type FETurbulence = raw.SVGFETurbulenceElement
+  @inline def FETurbulence = raw.SVGFETurbulenceElement
+  type Filter = raw.SVGFilterElement
+  type FilterPrimitiveStandardAttributes = raw.SVGFilterPrimitiveStandardAttributes
+  type FitToViewBox = raw.SVGFitToViewBox
+
+  type G = raw.SVGGElement
+  type GetSVGDocument = raw.GetSVGDocument
+  type Gradient = raw.SVGGradientElement
+  @inline def Gradient = raw.SVGGradientElement
+
+  type Image = raw.SVGImageElement
+
+  type LangSpace = raw.SVGLangSpace
+  type Length = raw.SVGLength
+  @inline def Length = raw.SVGLength
+  type LengthList = raw.SVGLengthList
+  type Line = raw.SVGLineElement
+  type LinearGradient = raw.SVGLinearGradientElement
+  type Locatable = raw.SVGLocatable
+
+  type Marker = raw.SVGMarkerElement
+  @inline def Marker = raw.SVGMarkerElement
+  type Mask = raw.SVGMaskElement
+  type Matrix = raw.SVGMatrix
+  type Metadata = raw.SVGMetadataElement
+
+  type Number = raw.SVGNumber
+  type NumberList = raw.SVGNumberList
+
+  type Path = raw.SVGPathElement
+  type PathSeg = raw.SVGPathSeg
+  @inline def PathSeg = raw.SVGPathSeg
+  type PathSegArcAbs = raw.SVGPathSegArcAbs
+  type PathSegArcRel = raw.SVGPathSegArcRel
+  type PathSegClosePath = raw.SVGPathSegClosePath
+  type PathSegCurvetoCubicSmoothAbs = raw.SVGPathSegCurvetoCubicSmoothAbs
+  type PathSegCurvetoQuadraticRel = raw.SVGPathSegCurvetoQuadraticRel
+  type PathSegCurvetoQuadraticSmoothRel = raw.SVGPathSegCurvetoQuadraticSmoothRel
+  type PathSegCurvetoCubicAbs = raw.SVGPathSegCurvetoCubicAbs
+  type PathSegCurvetoCubicRel = raw.SVGPathSegCurvetoCubicRel
+  type PathSegCurvetoQuadraticAbs = raw.SVGPathSegCurvetoQuadraticAbs
+  type PathSegCurvetoCubicSmoothRel = raw.SVGPathSegCurvetoCubicSmoothRel
+  type PathSegCurvetoQuadraticSmoothAbs = raw.SVGPathSegCurvetoQuadraticSmoothAbs
+  type PathSegLinetoAbs = raw.SVGPathSegLinetoAbs
+  type PathSegLinetoRel = raw.SVGPathSegLinetoRel
+  type PathSegLinetoHorizontalAbs = raw.SVGPathSegLinetoHorizontalAbs
+  type PathSegLinetoHorizontalRel = raw.SVGPathSegLinetoHorizontalRel
+  type PathSegLinetoVerticalAbs = raw.SVGPathSegLinetoVerticalAbs
+  type PathSegLinetoVerticalRel = raw.SVGPathSegLinetoVerticalRel
+  type PathSegMovetoAbs = raw.SVGPathSegMovetoAbs
+  type PathSegMovetoRel = raw.SVGPathSegMovetoRel
+  type PathSegList = raw.SVGPathSegList
+  type Pattern = raw.SVGPatternElement
+  type Point = raw.SVGPoint
+  type PointList = raw.SVGPointList
+  type Polygon = raw.SVGPolygonElement
+  type Polyline = raw.SVGPolylineElement
+  type PreserveAspectRatio = raw.SVGPreserveAspectRatio
+  @inline def PreserveAspectRatio = raw.SVGPreserveAspectRatio
+
+  type RadialGradient = raw.SVGRadialGradientElement
+  type Rect = raw.SVGRect
+  // Irregular aliasing, due to collision with dom.SVGRect
+  type RectElement = raw.SVGRectElement
+
+  type Script = raw.SVGScriptElement
+  type Stop = raw.SVGStopElement
+  type Stylable = raw.SVGStylable
+  type Style = raw.SVGStyleElement
+  type StringList = raw.SVGStringList
+  type SVG = raw.SVGSVGElement
+  type Switch = raw.SVGSwitchElement
+  type Symbol = raw.SVGSymbolElement
+
+  type Text = raw.SVGTextElement
+  type TextContent = raw.SVGTextContentElement
+  @inline def TextContent = raw.SVGTextContentElement
+  type TextPath = raw.SVGTextPathElement
+  @inline def TextPath = raw.SVGTextPathElement
+  type TextPositioning = raw.SVGTextPositioningElement
+  type Tests = raw.SVGTests
+  type Title = raw.SVGTitleElement
+  type Transform = raw.SVGTransform
+  @inline def Transform = raw.SVGTransform
+  type Transformable = raw.SVGTransformable
+  type TransformList = raw.SVGTransformList
+  type TSpan = raw.SVGTSpanElement
+
+  type UnitTypes = raw.SVGUnitTypes
+  @inline def UnitTypes = raw.SVGUnitTypes
+  type URIReference = raw.SVGURIReference
+  type Use = raw.SVGUseElement
+
+  type View = raw.SVGViewElement
+
+  type ZoomAndPan = raw.SVGZoomAndPan
+  @inline def ZoomAndPan = raw.SVGZoomAndPan
+  type ZoomEvent = raw.SVGZoomEvent
+}

--- a/src/main/scala/org/scalajs/dom/webgl.scala
+++ b/src/main/scala/org/scalajs/dom/webgl.scala
@@ -1,0 +1,19 @@
+package org.scalajs.dom
+
+/**
+ * Short aliasas of all the dom.WebGLThing classes
+ */
+object webgl {
+  type ActiveInfo = raw.WebGLActiveInfo
+  type Buffer = raw.WebGLBuffer
+  type ContextAttributes = raw.WebGLContextAttributes
+  type Framebuffer = raw.WebGLFramebuffer
+  type Program = raw.WebGLProgram
+  type Renderbuffer = raw.WebGLRenderbuffer
+  type RenderingContext = raw.WebGLRenderingContext
+  type Shader = raw.WebGLShader
+  type ShaderPrecisionFormat = raw.WebGLShaderPrecisionFormat
+  type Texture = raw.WebGLTexture
+  type UniformLocation = raw.WebGLUniformLocation
+  @inline def RenderingContext = raw.WebGLRenderingContext
+}


### PR DESCRIPTION
- The raw "everything goes" namespace is now org.scalajs.dom.raw
- org.scalajs.dom.{css, html, idb, svg, webgl} namespaces contain un-prefixed versions of the things that start with their prefix. The `Element` suffix has also been dropped where possible
- org.scalajs.dom.extensions has been renamed to org.scalajs.dom.ext
- org.scalajs.dom itself contains all things in org.scalajs.dom.raw that aren't in any of the un-prefixed namespaces

Overall, this should accomplish a few things:

- Massively clean up org.scalajs.dom.*, since we've moved ~270 names into proper namespaces
- Make dealing with these names much easier, e.g. now `dom.HTMLTableCellElement` is just `html.TableCell`
- Make a clear separation between "all un-modified dom facades" and "re-organized nice-to-use dom facades", so hopefully there won't be any confusion over things missing or where things should go
- Reasonable backwards compat just by changing imports: org.scalajs.dom -> org.scalajs.dom.raw and things should keep working

Some Caveats:

- The mapping isn't *quite* perfect: we still have `svg.RectElement` instead of just `svg.Rect`, sinct `svg.Rect` is taken by something else
- You don't get doc-dropdown in IntelliJ because of the aliases. I assume this is something we can bug the IntelliJ people to fix since it affects lots of other things (e.g. the std lib) and not just Scala.js