### PR TITLE
Add 'space' KeyCode to Extensions

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -102,6 +102,7 @@ object KeyCode {
   val pause = 19
   val capsLock = 20
   val escape = 27
+  val space = 32
   val pageUp = 33
   val pageDown = 34
   val end = 35


### PR DESCRIPTION
Or is this missing intentionally?