### PR TITLE
Added a method to AjaxException to check for timeout status.

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -157,7 +157,7 @@ import scala.concurrent.{Promise, Future}
  * Contains the XMLHttpRequest that resulted in that response
  */
 case class AjaxException(xhr: dom.XMLHttpRequest) extends Exception {
-  def timeout = xhr.status == 0 && xhr.readyState == 4
+  def isTimeout = xhr.status == 0 && xhr.readyState == 4
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -154,9 +154,12 @@ object KeyCode {
 import scala.concurrent.{Promise, Future}
 /**
  * Thrown when `Ajax.get` or `Ajax.post` receives a non-20X response code.
- * Contains the XMLHttpRequest that resulted in that respons
+ * Contains the XMLHttpRequest that resulted in that response
  */
-case class AjaxException(xhr: dom.XMLHttpRequest) extends Exception
+case class AjaxException(xhr: dom.XMLHttpRequest) extends Exception {
+  def timeout = xhr.status == 0 && xhr.readyState == 4
+}
+
 /**
  * Wraps an XMLHttpRequest to provide an easy one-line way of making 
  * an Ajax call, returning a Future.


### PR DESCRIPTION
As XHR doesn't offer a clear status for indicating timeout, this method provides an easier way to check for timeout. Tried also using `ontimeout` but it gets called after `onreadystatechange` making it rather useless in this case.

Change-Id: Ia0d66bd4ca27f2ce0157258bcc885817efe21a2f