### PR TITLE
GeoLocation Position -> timestamp should be double

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -5120,7 +5120,7 @@ trait Position extends js.Object {
    *
    * MDN
    */
-  def timestamp: Int = js.native
+  def timestamp: Double = js.native
 
   /**
    * The Position.coords read-only property, a Coordinates object, represents a


### PR DESCRIPTION
i got the following error with current code

```scala
Uncaught scala.scalajs.runtime.UndefinedBehaviorError: An undefined behavior was detected: 1425095692856 is not an instance of java.lang.Integer ...
```
when i cast Position to js.Dynamic and then timestamp to Double it worked fine.