### PR TITLE
Fix WebGL clearDepth signature

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebGL.scala
@@ -1012,7 +1012,7 @@ class WebGLRenderingContext extends js.Object {
   /**
    * Sets the clear depth to use with [[WebGLRenderingContext#clear]].
    */
-  def clearDepth(depth: Int): Unit = js.native
+  def clearDepth(depth: Double): Unit = js.native
 
   /**
    * Sets the stencil value to use with [[WebGLRenderingContext#clear]].


### PR DESCRIPTION
One more silly signature issue.  Integer depths for a depth buffer clamped from 0..1 aren't very useful :)