### PR TITLE
Fix #94: Remove erroneous MutationObserverInit export

### DIFF
--- a/src/main/scala/org/scalajs/dom/package.scala
+++ b/src/main/scala/org/scalajs/dom/package.scala
@@ -113,7 +113,6 @@ package object dom extends Window with scalajs.js.GlobalScope {
   val MutationEvent: raw.MutationEvent.type = js.native
   type MutationObserver = raw.MutationObserver
   type MutationObserverInit = raw.MutationObserverInit
-  val MutationObserverInit: raw.MutationObserverInit.type = js.native
   type MutationRecord = raw.MutationRecord
 
   type NamedNodeMap = raw.NamedNodeMap


### PR DESCRIPTION
Unfortuntely, due to #121 we can't sensibly export this object without a *massive* reworking of the entire `org.scalajs.dom` package.

Might as well at least remove it for now, given anyone using this export will get surprising runtime errors.