### PR TITLE
Fix #132: Add Image onload

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -1310,6 +1310,7 @@ abstract class HTMLImageElement extends HTMLElement {
 
   def create(): HTMLImageElement = js.native
 
+  var onload: js.Function1[Event, _] = js.native
 }
 
 /**


### PR DESCRIPTION
Not much to say, here.  Adds `HTMLImageElement.onload`.