### PR TITLE
Turn Promise trait into a class with executor constructor parameter.

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -471,7 +471,7 @@ trait WindowTimers extends WindowTimersExtension {
  *
  * MDN
  */
-trait Promise[+A] extends js.Object {
+class Promise[+A](executor: js.Function2[js.Function1[A, Any], js.Function1[Any, Any], Any]) extends js.Object {
 
   /**
    * The catch() method returns a Promise and deals with rejected cases only.


### PR DESCRIPTION
I write a js library, that converts scala Futures into javascript Promises. To instantiate a Promise within scala.js code it needs to be a class