### PR TITLE
DataTransfer.setData() return type can be undefined

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -3777,7 +3777,7 @@ trait DataTransfer extends js.Object {
    *
    * MDN
    */
-  def setData(format: String, data: String): Boolean = js.native
+  def setData(format: String, data: String): js.UndefOr[Boolean] = js.native
 
   /**
    * Retrieves the data for a given type, or an empty string if data for that type does not


### PR DESCRIPTION
In latest Chrome I'm get:
```
Uncaught scala.scalajs.runtime.UndefinedBehaviorError:
An undefined behavior was detected: undefined is not an instance of java.lang.Boolean
```