### PR TITLE
Fix Touch identifier to be Double

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2586,7 +2586,7 @@ class Touch extends js.Object {
    *
    * MDN
    */
-  def identifier: Int = js.native
+  def identifier: Double = js.native
 
   /**
    * The X coordinate of the touch point relative to the left edge of the screen.


### PR DESCRIPTION
`identifier` on the`Touch`class is specified as a `long` http://www.w3.org/TR/touch-events/#idl-def-Touch.  I'm seeing `UndefinedBehaviourError` under iOS safari when the identifier is outside the range of an Int.