### PR TITLE
fix refrence in JSName to point to correct javascript object

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/Notification.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Notification.scala
@@ -211,7 +211,7 @@ object Notification extends js.Object {
  * @param options   The options to configure this notification
  * @return a new Notification
  */
-@JSName("Notification.Notification")
+@JSName("Notification")
 @js.native
 class Notification(
     title: String,


### PR DESCRIPTION
Was getting an error when calling new Notification.  Changing it to the below JSName appears to fix the problem.