### PR TITLE
Window: `pageXOffset` and `pageYOffset` are Double

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1931,7 +1931,7 @@ class Window extends EventTarget with WindowLocalStorage
    *
    * MDN
    */
-  def pageXOffset: Int = js.native
+  def pageXOffset: Double = js.native
 
   /**
    * The name of the window is used primarily for setting targets for hyperlinks and
@@ -2108,7 +2108,7 @@ class Window extends EventTarget with WindowLocalStorage
    *
    * MDN
    */
-  def pageYOffset: Int = js.native
+  def pageYOffset: Double = js.native
 
   /**
    * An event handler property for right-click events on the window.


### PR DESCRIPTION
Page offsets are not necessarily Integer values. The following exception was thrown when I tried to access `pageYOffset`:

```
java.lang.ClassCastException: 525.6000125312809 is not an instance of java.lang.Integer
```