### PR TITLE
added CryptoKeyPair trait. Fix RsaHashedKeyGenParams

### DIFF
--- a/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
+++ b/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
@@ -71,15 +71,33 @@ object HashAlgorithm {
   val `SHA-512` = named("SHA-512")
 }
 
+/**
+ * The CryptoKey object represents an opaque reference to keying material that
+ * is managed by the user agent.
+ *
+ * defined at [[http://www.w3.org/TR/WebCryptoAPI/#cryptokey-interface ¶13 The CryptoKey Interface]]
+ */
 @js.native
 trait CryptoKey extends js.Object {
   val `type`: String = js.native
 
   val extractable: Boolean = js.native
 
-  val algorithm: js.Object = js.native
+  val algorithm: KeyAlgorithm = js.native
 
-  val usages: js.Object = js.native
+  val usages: js.Array[KeyUsage] = js.native
+}
+
+/**
+ * The CryptoKeyPair dictionary represents an asymmetric key pair that is comprised
+ * of both public and private keys.
+ * defined at [[http://www.w3.org/TR/WebCryptoAPI/#keypair ¶17 CryptoKeyPair dictionary]]
+ * of spec
+ */
+@js.native
+trait CryptoKeyPair extends js.Object {
+  val publicKey: CryptoKey = js.native
+  val privateKey: CryptoKey = js.native
 }
 
 @js.native
@@ -337,9 +355,9 @@ trait RsaHashedKeyGenParams extends RsaKeyGenParams {
 @js.native
 object RsaHashedKeyGenParams {
   @inline
-  def apply(modulusLength: Long,
+  def apply(name: String, modulusLength: Long,
       publicExponent: BigInteger, hash: HashAlgorithmIdentifier): RsaHashedKeyGenParams = {
-    js.Dynamic.literal(name = "RSASSA-PKCS1-v1_5", modulusLength = modulusLength.toDouble,
+    js.Dynamic.literal(name = name, modulusLength = modulusLength.toDouble,
         publicExponent = publicExponent,
         hash = hash.asInstanceOf[js.Any]).asInstanceOf[RsaHashedKeyGenParams]
   }
@@ -383,6 +401,13 @@ object RsaHashedKeyAlgorithm {
     js.Dynamic.literal(name = name, modulusLength = modulusLength.toDouble,
         publicExponent = publicExponent,
         hash = hash.asInstanceOf[js.Any]).asInstanceOf[RsaHashedKeyAlgorithm]
+  }
+
+  def `RSASSA-PKCS1-v1_5`(
+    modulusLength: Long,
+    publicExponent: BigInteger,
+    hash: HashAlgorithmIdentifier): RsaHashedKeyAlgorithm = {
+    apply("RSASSA-PKCS1-v1_5",modulusLength,publicExponent,hash)
   }
 }
 
@@ -866,3 +891,9 @@ object KeyFormat {
   /** The key is a JsonWebKey dictionary encoded as a JavaScript object */
   val jwk = "jwk".asInstanceOf[KeyFormat]
 }
+
+//
+// types defined in JSON Web Key (JWK) RFC
+// http://tools.ietf.org/html/rfc7517
+//
+

--- a/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
+++ b/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
@@ -403,11 +403,34 @@ object RsaHashedKeyAlgorithm {
         hash = hash.asInstanceOf[js.Any]).asInstanceOf[RsaHashedKeyAlgorithm]
   }
 
+  /**
+   * see [[http://www.w3.org/TR/WebCryptoAPI/#rsassa-pkcs1 ¶20. RSASSA-PKCS1-v1_5]] of w3c spec
+   */
   def `RSASSA-PKCS1-v1_5`(
-    modulusLength: Long,
-    publicExponent: BigInteger,
-    hash: HashAlgorithmIdentifier): RsaHashedKeyAlgorithm = {
-    apply("RSASSA-PKCS1-v1_5",modulusLength,publicExponent,hash)
+      modulusLength: Long,
+      publicExponent: BigInteger,
+      hash: HashAlgorithmIdentifier): RsaHashedKeyAlgorithm = {
+    apply("RSASSA-PKCS1-v1_5", modulusLength, publicExponent, hash)
+  }
+
+  /**
+   * see [[http://www.w3.org/TR/WebCryptoAPI/#rsa-pss ¶21. RSA-PSS]] of w3c spec
+   */
+  def `RSA-PSS`(
+      modulusLength: Long,
+      publicExponent: BigInteger,
+      hash: HashAlgorithmIdentifier): RsaHashedKeyAlgorithm = {
+    apply("RSA-PSS", modulusLength, publicExponent, hash)
+  }
+
+  /**
+   * see [[http://www.w3.org/TR/WebCryptoAPI/#rsa-pss ¶21. RSA-OAEP]] of w3c spec
+   */
+  def `RSA-OAEP`(
+      modulusLength: Long,
+      publicExponent: BigInteger,
+      hash: HashAlgorithmIdentifier): RsaHashedKeyAlgorithm = {
+    apply("RSA-OAEP", modulusLength, publicExponent, hash)
   }
 }
 
@@ -893,7 +916,22 @@ object KeyFormat {
 }
 
 //
-// types defined in JSON Web Key (JWK) RFC
+// Todo: fill in the full list of types defined in JSON Web Key (JWK) RFC
 // http://tools.ietf.org/html/rfc7517
 //
 
+/**
+ * see example http://tools.ietf.org/html/rfc7517#appendix-A.1
+ * //todo: where is the specification of n and e?
+ */
+@js.native
+trait RSAPublicKey extends js.Object {
+
+  /* modulus, as a base64 URL encoded String */
+  @js.native
+  def n: String = js.native
+
+  /* exponent, as a base64 URL encoded String */
+  @js.native
+  def e: String = js.native
+}

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -672,18 +672,20 @@ class IDBOpenDBRequest extends IDBRequest {
  * access the indexed databases. The object that implements the interface is
  * window.indexedDB. You open — that is, create and access — and delete a
  * database with the object and not directly with IDBFactory.
+ * see [[https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory IDBFactory on MDN]]
  *
- * MDN
+ * official documentation [[http://www.w3.org/TR/IndexedDB/#idl-def-IDBFactory IDBFactory]] in w3c spec
+ *
  */
 @js.native
 class IDBFactory extends js.Object {
   def open(name: String, version: Int): IDBOpenDBRequest = js.native
 
   /**
-   * An obsolete method to request opening a connection to a database, still
-   * implemented by some browsers.
+   * The open() method of the IDBFactory interface requests opening a connection to a database.
+   * see [[https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open IDBFactory.open() on MDN]]
    *
-   * MDN
+   * w3c spec [[http://www.w3.org/TR/IndexedDB/#requests ¶3.2.3 Opening a database]]
    */
   def open(name: String): IDBOpenDBRequest = js.native
 


### PR DESCRIPTION
Implementing [HTTP-Signature](https://tools.ietf.org/html/draft-cavage-http-signatures-05) (see:   [KeyStore.scala](https://github.com/read-write-web/rww-scala-js/blob/7667bb1473fae1909c6503251e08f4a05287b577/src/main/scala/rww/store/KeyStore.scala)), I found the need for the CryptoKeyPair trait. 

During discussions to get that to work, I also discovered that a previous change of mine was mistaken.

And I found a documentation bug.