### PR TITLE
make NodeList items have Element properties

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -5693,7 +5693,7 @@ trait DOMList[T] extends js.Object{
  * MDN
  */
 @js.native
-class NodeList extends DOMList[Node]
+class NodeList extends DOMList[Element]
 
 
 @js.native


### PR DESCRIPTION
make NodeList items have Element properties

Extending `Element` gives methods like `getElementById`, `innerHTML`.

`NodeList` itself can be obtained by using
`getElementsByClassName`, `childNodes` etc.

I could not find an explicit type definition for NodeList elements,
but it seems that all major browsers understand NodeList similarly.

NB: Merge with care! JS is not my expertise area.