### PR TITLE
upgrade to travis docker infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: scala
 script:
   - sbt ++$TRAVIS_SCALA_VERSION package doc


### PR DESCRIPTION
Travis warning: 

> This job ran on our legacy infrastructure. Please read our docs on how to upgrade.

This PR let scala-js-dom builds run against the new infrastructure (wonder if it works, trying it with this PR). 
This should speed up the travis build.

Further steps could be to configure ivy caching (speeds up build and saves some mb traffic, avoid compiler facade recompilation). 