### PR TITLE
Html.disabled can be undefined

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -3646,7 +3646,7 @@ abstract class HTMLElement extends Element {
   var onloadeddata: js.Function1[Event, _] = js.native
   var onbeforedeactivate: js.Function1[UIEvent, _] = js.native
 
-  var disabled: Boolean = js.native
+  var disabled: js.UndefOr[Boolean] = js.native
   var onactivate: js.Function1[UIEvent, _] = js.native
   var onselectstart: js.Function1[Event, _] = js.native
   var ontimeupdate: js.Function1[Event, _] = js.native


### PR DESCRIPTION
Calling `.disabled` on elements like `HTMLImageElement`, `HTMLDivElement`, `HTMLParagraphElement` type-checks and causes this nastiness (at least in Chrome):

```
Uncaught scala.scalajs.runtime.UndefinedBehaviorError:
An undefined behavior was detected: undefined is not an instance of java.lang.Boolean
```