### PR TITLE
Make File an abstract class

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -6615,7 +6615,7 @@ trait FileList extends DOMList[File]
  * MDN
  */
 @js.native
-trait File extends Blob {
+abstract class File extends Blob {
   /**
    * Returns the last modified date of the file. Files without a known last modified date
    * use the current date instead.


### PR DESCRIPTION
... such that `foo.isInstanceOf[org.scalajs.dom.raw.File]` and `match ... case file: File ⇒` are supported.