### PR TITLE
Add console back to the dom package.

### DIFF
--- a/src/main/scala/org/scalajs/dom/package.scala
+++ b/src/main/scala/org/scalajs/dom/package.scala
@@ -219,4 +219,6 @@ package object dom {
 
   lazy val window: Window = js.Dynamic.global.asInstanceOf[Window]
   lazy val document: html.Document = window.document
+
+  lazy val console: Console = window.console
 }


### PR DESCRIPTION
These disappeared from the dom package when we stopped using a js.native package object, so add them back to prevent needlessly breaking code in 0.9.0.