### PR TITLE
Make Window.innerWidth and innerHeight Double

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1821,7 +1821,7 @@ class Window extends EventTarget with WindowLocalStorage
    *
    * MDN
    */
-  def innerWidth: Int = js.native
+  def innerWidth: Double = js.native
 
   /**
    * Gets the height of the content area of the browser window including, if rendered,
@@ -1829,7 +1829,7 @@ class Window extends EventTarget with WindowLocalStorage
    *
    * MDN
    */
-  def innerHeight: Int = js.native
+  def innerHeight: Double = js.native
 
   var onwaiting: js.Function1[Event, _] = js.native
   var ononline: js.Function1[Event, _] = js.native


### PR DESCRIPTION
See: https://www.w3.org/TR/cssom-view/#extensions-to-the-window-interface

Note- this doesn't appear to be an issue in any current browser (I suppose viewports tend to be integer width in the underlying OS), but the spec does mention `Double`, not `Int`.