### PR TITLE
un-deprecate AudioBufferSourceNode.buffer

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Audio.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Audio.scala
@@ -437,7 +437,6 @@ trait AudioBufferSourceNode extends AudioNode {
   /** Is an AudioBuffer that defines the audio asset to be played, or when
    *  set to the value null, defines a single channel of silence.
    */
-  @deprecated("Should no longer be used, but will probably still work.", "forever")
   var buffer: AudioBuffer = js.native
 
   /** Is an a-rate AudioParam that defines the speed factor at which the


### PR DESCRIPTION
It seems that it is the way to go according to the [spec](https://www.w3.org/TR/webaudio/#widl-AudioBufferSourceNode-buffer).