### PR TITLE
Export AjaxException members to better support Future.toPromise and Ajax Futures.

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -3,15 +3,15 @@ package org.scalajs.dom.ext
 import java.nio.ByteBuffer
 
 import scala.language.implicitConversions
-import scala.concurrent.{Promise, Future}
-
+import scala.concurrent.{Future, Promise}
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 import scala.scalajs.js.typedarray.TypedArrayBufferOps._
-
 import org.scalajs.dom
 import org.scalajs.dom.{FormData, html, raw}
 import org.scalajs.dom.raw.Blob
+
+import scala.scalajs.js.annotation.{JSExport, JSExportAll}
 
 
 /**
@@ -234,6 +234,8 @@ object KeyCode {
  * Thrown when `Ajax.get` or `Ajax.post` receives a non-20X response code.
  * Contains the XMLHttpRequest that resulted in that response
  */
+@JSExport
+@JSExportAll
 case class AjaxException(xhr: dom.XMLHttpRequest) extends Exception {
   def isTimeout = xhr.status == 0 && xhr.readyState == 4
 }

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -11,7 +11,7 @@ import org.scalajs.dom
 import org.scalajs.dom.{FormData, html, raw}
 import org.scalajs.dom.raw.Blob
 
-import scala.scalajs.js.annotation.{JSExport, JSExportAll}
+import scala.scalajs.js.annotation.JSExportAll
 
 
 /**
@@ -234,7 +234,6 @@ object KeyCode {
  * Thrown when `Ajax.get` or `Ajax.post` receives a non-20X response code.
  * Contains the XMLHttpRequest that resulted in that response
  */
-@JSExport
 @JSExportAll
 case class AjaxException(xhr: dom.XMLHttpRequest) extends Exception {
   def isTimeout = xhr.status == 0 && xhr.readyState == 4


### PR DESCRIPTION
When using the rich future JSConverter to return a JS Promise from a Future that performs an AJAX request it is possible that the JS caller will be returned an AjaxException to handle in a rejected promise. In these cases is it useful for the JS client to have access to the XHR request itself to better handle the failure. This change simply makes the XHR that caused the exception available to the JS caller.