### PR TITLE
Expose existing URL trait as window.URL

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1928,6 +1928,13 @@ class Window extends EventTarget with WindowLocalStorage
    */
   def document: HTMLDocument = js.native
 
+  /**
+   * Returns an object that provides static methods used for creating and managing object URLs.
+   *
+   * MDN
+   */
+  def URL: URL = js.native
+
   var onprogress: js.Function1[js.Any, _] = js.native
   var ondblclick: js.Function1[MouseEvent, _] = js.native
 


### PR DESCRIPTION
While the dom package object defines a URL type, its methods are not actually reachable.

This PR exposes it as `window.URL`

I hope this is the right place and style. Feels weird to use all-caps for a def, but afaik native JS classes may not have inner objects, right?
