### PR TITLE
Facade to WebVR API (draft 27 July 2016)

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -7,6 +7,7 @@
 package org.scalajs.dom.experimental.gamepad
 
 import org.scalajs.dom
+import org.scalajs.dom.experimental.webvr.GamepadWebVR
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
@@ -36,7 +37,7 @@ trait GamepadButton extends js.Any {
  * Represents the state of a connected gamepad device.
  */
 @ScalaJSDefined
-trait Gamepad extends js.Any {
+trait Gamepad extends js.Any  {
 
   /** The identification string for the gamepad. */
   val id: String
@@ -65,6 +66,9 @@ trait Gamepad extends js.Any {
    * The layout of the gamepad.  Either "standard" or unknown ("").
    */
   val mapping: GamepadMappingType
+
+  /** the displayId for the associated VRDisplay. */
+  val displayId: Int = js.native
 }
 
 @ScalaJSDefined

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -7,7 +7,6 @@
 package org.scalajs.dom.experimental.gamepad
 
 import org.scalajs.dom
-import org.scalajs.dom.experimental.webvr.GamepadWebVR
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
@@ -37,7 +36,7 @@ trait GamepadButton extends js.Any {
  * Represents the state of a connected gamepad device.
  */
 @ScalaJSDefined
-trait Gamepad extends js.Any with GamepadWebVR {
+trait Gamepad extends js.Any {
 
   /** The identification string for the gamepad. */
   val id: String

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -7,7 +7,6 @@
 package org.scalajs.dom.experimental.gamepad
 
 import org.scalajs.dom
-import org.scalajs.dom.experimental.webvr.GamepadWebVR
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
@@ -68,7 +67,7 @@ trait Gamepad extends js.Any  {
   val mapping: GamepadMappingType
 
   /** the displayId for the associated VRDisplay. */
-  val displayId: Int = js.native
+  val displayId: Int
 }
 
 @ScalaJSDefined

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -7,8 +7,10 @@
 package org.scalajs.dom.experimental.gamepad
 
 import org.scalajs.dom
+import org.scalajs.dom.experimental.webvr.GamepadWebVR
+
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{ScalaJSDefined, JSName}
+import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
 
 @js.native
 trait GamepadMappingType extends js.Any
@@ -35,7 +37,7 @@ trait GamepadButton extends js.Any {
  * Represents the state of a connected gamepad device.
  */
 @ScalaJSDefined
-trait Gamepad extends js.Any {
+trait Gamepad extends js.Any with GamepadWebVR {
 
   /** The identification string for the gamepad. */
   val id: String

--- a/src/main/scala/org/scalajs/dom/experimental/offscreencanvas/OffscreenCanvas.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/offscreencanvas/OffscreenCanvas.scala
@@ -1,0 +1,73 @@
+package org.scalajs.dom.experimental.offscreencanvas
+
+/**
+  * The OffscreenCanvas interface provides a canvas that can be rendered off screen.
+  * It is available in both the window and worker contexts.
+  *
+  * see [[https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas]]
+  * and [[https://wiki.whatwg.org/wiki/OffscreenCanvas]]
+  */
+
+import org.scalajs.dom.raw.ImageBitmap
+import org.scalajs.dom.Blob
+import org.scalajs.dom.webgl.RenderingContext
+
+import scala.concurrent.Promise
+import scala.scalajs.js
+
+
+/**
+  * OffscreenCanvas constructor. Creates a new OffscreenCanvas object.
+  *
+  * @param width  The width of the offscreen canvas.
+  * @param height The height of the offscreen canvas.
+  */
+@js.native
+class OffscreenCanvas(width: Int, height: Int) extends js.Object {
+
+  /**
+    * The OffscreenCanvas.getContext() method returns a drawing context for an offscreen canvas,
+    * or null if the context identifier is not supported.
+    *
+    * @param contextType       a DOMString containing the context identifier defining the drawing context associated to the canvas.
+    *                          One off: "2d", "webgl", "webgl2" and "bitmaprenderer"
+    * @param contextAttributes context attributes,
+    *                          "2d" context attributes:
+    *                          alpha: Boolean that indicates if the canvas contains an alpha channel. If set to false, the browser now knows that the backdrop is always opaque, which can speed up drawing of transparent content and images then.
+    *                          (Gecko only) willReadFrequently: Boolean that indicates whether or not a lot of read-back operations are planned. This will force the use of a software (instead of hardware accelerated) 2D canvas and can save memory when calling getImageData() frequently. This option is only available, if the flag gfx.canvas.willReadFrequently.enable is set to true (which, by default, is only the case for B2G/Firefox OS).
+    *                          (Blink only) storage: String that indicates which storage is used ("persistent" by default).
+    *                          "WebGL" context attributes:
+    *                          alpha: Boolean that indicates if the canvas contains an alpha buffer.
+    *                          depth: Boolean that indicates that the drawing buffer has a depth buffer of at least 16 bits.
+    *                          stencil: Boolean that indicates that the drawing buffer has a stencil buffer of at least 8 bits.
+    *                          antialias: Boolean that indicates whether or not to perform anti-aliasing.
+    *                          premultipliedAlpha: Boolean that indicates that the page compositor will assume the drawing buffer contains colors with pre-multiplied alpha.
+    *                          preserveDrawingBuffer: If the value is true the buffers will not be cleared and will preserve their values until cleared or overwritten by the author.
+    *                          failIfMajorPerformanceCaveat: Boolean that indicates if a context will be created if the system performance is low.
+    * @return A RenderingContext which is either a
+    *         CanvasRenderingContext2D for "2d",
+    *         WebGLRenderingContext for "webgl" and "experimental-webgl",
+    *         WebGL2RenderingContext for "webgl2" and "experimental-webgl2" , or
+    *         ImageBitmapRenderingContext for "bitmaprenderer".
+    */
+  def getContext(contextType: String, contextAttributes: js.Any*): RenderingContext = js.native
+
+  /** The OffscreenCanvas.toBlob() method creates a Blob object representing the image contained in the canvas
+    *
+    * @param `type`         type Optional, a DOMString indicating the image format.
+    *                       The default type is image/png.
+    * @param encoderOptions encoderOptions Optional
+    *                       A Number between 0 and 1 indicating image quality if the requested type is
+    *                       image/jpeg or image/webp. If this argument is anything else,
+    *                       the default value for image quality is used. Other arguments are ignored.
+    * @return A Promise returning a Blob object representing the image contained in the canvas.
+    */
+  def toBlob(`type`: Option[String], encoderOptions: js.Any*): Promise[Blob] = js.native
+
+  /**
+    * The OffscreenCanvas.transferToImageBitmap() method creates an ImageBitmap object from the most
+    * recently rendered image of the OffscreenCanvas.
+    */
+  def transferToImageBitmap(): ImageBitmap = js.native
+
+}

--- a/src/main/scala/org/scalajs/dom/experimental/offscreencanvas/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/offscreencanvas/package.scala
@@ -1,0 +1,10 @@
+package org.scalajs.dom.experimental
+
+/**
+  * The OffscreenCanvas interface provides a canvas that can be rendered off screen.
+  * It is available in both the window and worker contexts.
+  *
+  * see [[https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas]]
+  * and [[https://wiki.whatwg.org/wiki/OffscreenCanvas]]
+  */
+package object offscreencanvas

--- a/src/main/scala/org/scalajs/dom/experimental/screenorientation/ScreenOrientation.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/screenorientation/ScreenOrientation.scala
@@ -1,0 +1,94 @@
+package org.scalajs.dom.experimental.screenorientation
+
+/**
+  * Extensions to the Screen interface.
+  *
+  * Façade to the Screen Orientation API, W3C Working Draft 21 July 2016
+  *
+  * [[https://www.w3.org/TR/screen-orientation]]
+  */
+
+import org.scalajs.dom.experimental.webvr.EventHandler
+import org.scalajs.dom.raw.EventTarget
+
+import scala.scalajs.js
+import scala.scalajs.js.Promise
+import scala.scalajs.js.annotation._
+import scala.language.implicitConversions
+
+/**
+  * The Screen Orientation API provides the ability to read the screen orientation type and angle,
+  * to be informed when the screen orientation state changes, and be able to lock the screen orientation to a specific state.
+  */
+@js.native
+trait ScreenOrientation extends EventTarget {
+
+  /**
+    * When the lock() method is invoked, the user agent must run the apply an orientation lock steps to the responsible document using orientation.
+    */
+  def lock(orientation: String): Promise[Unit] = js.native
+
+  /**
+    * When the unlock() method is invoked, the user agent must run the steps to lock the orientation of the responsible document to the responsible document's default orientation.
+    */
+  def unlock(): Unit = js.native
+
+  /**
+    * When getting the type attribute, the user agent must return the responsible document's current orientation type.
+    */
+  def `type`: String = js.native
+
+  /**
+    * When getting the angle attribute, the user agent must return the responsible document's current orientation angle.
+    */
+  def angle: Int = js.native
+
+  /**
+    * The onchange attribute is an event handler whose corresponding event handler event type is change.
+    */
+  def onchange: EventHandler = js.native
+
+}
+
+/**
+  * the OrientationType
+  */
+object OrientationType extends Enumeration {
+  type OrientationType = Value
+
+  @JSName("portrait-primary")
+  val portraitPrimary = Value("portrait-primary")
+
+  @JSName("portrait-secondary")
+  val portraitSecondary = Value("portrait-secondary")
+
+  @JSName("landscape-primary")
+  val landscapePrimary = Value("landscape-primary")
+
+  @JSName("landscape-secondary")
+  val landscapeSecondary = Value("landscape-secondary")
+}
+
+/**
+  * the OrientationLockType
+  */
+object OrientationLockType extends Enumeration {
+  type OrientationLockType = Value
+
+  val any = Value("any")
+  val natural = Value("natural")
+  val landscape = Value("landscape")
+  val portrait = Value("portrait")
+
+  @JSName("portrait-primary")
+  val portraitPrimary = Value("portrait-primary")
+
+  @JSName("portrait-secondary")
+  val portraitSecondary = Value("portrait-secondary")
+
+  @JSName("landscape-primary")
+  val landscapePrimary = Value("landscape-primary")
+
+  @JSName("landscape-secondary")
+  val landscapeSecondary = Value("landscape-secondary")
+}

--- a/src/main/scala/org/scalajs/dom/experimental/screenorientation/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/screenorientation/package.scala
@@ -1,0 +1,20 @@
+package org.scalajs.dom.experimental
+
+import org.scalajs.dom.experimental.screenorientation.OrientationLockType.OrientationLockType
+import org.scalajs.dom.experimental.screenorientation.OrientationType.OrientationType
+import scala.language.implicitConversions
+
+/**
+ * Façade to the Screen Orientation API, W3C Working Draft 21 July 2016
+ *
+ * [[https://www.w3.org/TR/screen-orientation]]
+ */
+package object screenorientation {
+
+  /** converts OrientationType to its string representation */
+  implicit def OrientationTypeToString(t: OrientationType): String = t.toString
+
+  /** converts OrientationLockType to its string representation */
+  implicit def OrientationLockTypeToString(t: OrientationLockType): String = t.toString
+
+}

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
@@ -1,0 +1,368 @@
+package org.scalajs.dom.experimental.webvr
+
+/*
+ * Façade to the WebVR API, Editor’s Draft, 27 July 2016.
+ *
+ * [[https://w3c.github.io/webvr/]]
+ *
+ */
+
+import org.scalajs.dom._
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.{Promise => _, _}
+import scala.scalajs.js.typedarray.Float32Array
+import scala.concurrent._
+import scala.language.implicitConversions
+
+
+/**
+  * The VRLayer interface is provided to a VRDisplay and presented in the HMD.
+  */
+@ScalaJSDefined
+trait VRLayer extends js.Object {
+  /** The source attribute defines the canvas whose contents will be presented by the VRDisplay when VRDisplay.submitFrame() is called. */
+  var source: VRSource
+  /** The leftBounds attribute contains four values defining the texture bounds within the
+    * source canvas to present to the eye in UV space:
+    * [0] left offset of the bounds (0.0 - 1.0);
+    * [1] top offset of the bounds (0.0 - 1.0); [2] width of the bounds (0.0 - 1.0); [3] height of the bounds (0.0 - 1.0).
+    * The leftBounds MUST default to [0.0, 0.0, 0.5, 1.0].
+    */
+  var leftBounds: js.Array[Float]
+  /**
+    * The rightBounds attribute contains four values defining the texture bounds rectangle within the
+    * source canvas to present to the eye in UV space:
+    * [0] left offset of the bounds (0.0 - 1.0);
+    * [1] top offset of the bounds (0.0 - 1.0);
+    * [2] width of the bounds (0.0 - 1.0);
+    * [3] height of the bounds (0.0 - 1.0).
+    * The rightBounds MUST default to [0.5, 0.0, 0.5, 1.0].
+    */
+  var rightBounds: js.Array[Float]
+}
+
+object VRLayer {
+  def apply(source: VRSource, leftBounds: js.Array[Float], rightBounds: js.Array[Float]): VRLayer = {
+    js.Dynamic
+      .literal(source = source.merge[js.Any], leftBounds = leftBounds, rightBounds = rightBounds)
+      .asInstanceOf[VRLayer]
+  }
+}
+
+/**
+  * The VRDisplay interface forms the base of all VR devices supported by this API.
+  * It includes generic information such as device IDs and descriptions.
+  */
+@js.native
+trait VRDisplay extends EventTarget {
+  def isConnected: Boolean = js.native
+
+  def isPresenting: Boolean = js.native
+
+  /** Dictionary of capabilities describing the VRDisplay. */
+  val capabilities: VRDisplayCapabilities = js.native
+
+  /**
+    * If this VRDisplay supports room-scale experiences, the optional
+    * stage attribute contains details on the room-scale parameters.
+    */
+  def stageParameters: VRStageParameters = js.native
+
+  /* Return the current VREyeParameters for the given eye. */
+  def getEyeParameters(whichEye: String): VREyeParameters = js.native
+
+  /**
+    * An identifier for this distinct VRDisplay. Used as an
+    * association point in the Gamepad API.
+    */
+  val displayId: Int = js.native
+  /** A display name, a user-readable name identifying it. */
+  val displayName: String = js.native
+
+  /**
+    * Return a VRPose containing the future predicted pose of the VRDisplay
+    * when the current frame will be presented. The value returned will not
+    * change until JavaScript has returned control to the browser.
+    *
+    * The VRPose will contain the position, orientation, velocity,
+    * and acceleration of each of these properties.
+    */
+  def getPose(): VRPose = js.native
+
+  /**
+    * Return the current instantaneous pose of the VRDisplay, with no
+    * prediction applied.
+    */
+  def getImmediatePose(): VRPose = js.native
+
+  /**
+    * Reset the pose for this display, treating its current position and
+    * orientation as the "origin/zero" values. VRPose.position,
+    * VRPose.orientation, and VRStageParameters.sittingToStandingTransform may be
+    * updated when calling resetPose(). This should be called in only
+    * sitting-space experiences.
+    */
+  def resetPose(): Unit = js.native
+
+  /**
+    * z-depth defining the near plane of the eye view frustum
+    * enables mapping of values in the render target depth
+    * attachment to scene coordinates. Initially set to 0.01.
+    */
+  var depthNear: Double = js.native
+  /**
+    * z-depth defining the far plane of the eye view frustum
+    * enables mapping of values in the render target depth
+    * attachment to scene coordinates. Initially set to 10000.0.
+    */
+  var depthFar: Double = js.native
+
+  /**
+    * The callback passed to "requestAnimationFrame" will be called
+    * any time a new frame should be rendered. When the VRDisplay is
+    * presenting the callback will be called at the native refresh
+    * rate of the HMD. When not presenting this function acts
+    * identically to how window.requestAnimationFrame acts. Content should
+    * make no assumptions of frame rate or vsync behavior as the HMD runs
+    * asynchronously from other displays and at differing refresh rates.
+    */
+  def requestAnimationFrame(callback: js.Function): Int = js.native
+
+  /**
+    * Passing the value returned by requestAnimationFrame to
+    * cancelAnimationFrame will unregister the callback.
+    */
+  def cancelAnimationFrame(handle: Int): Unit = js.native
+
+  /**
+    * Begin presenting to the VRDisplay. Must be called in response to a user gesture.
+    * Repeat calls while already presenting will update the VRLayers being displayed.
+    */
+  def requestPresent(layers: js.Array[VRLayer]): Promise[Unit] = js.native
+
+  /** Stops presenting to the VRDisplay. */
+  def exitPresent(): Promise[Unit] = js.native
+
+  /** Get the layers currently being presented. */
+  def getLayers(): js.Array[VRLayer] = js.native
+
+  /**
+    * The VRLayer provided to the VRDisplay will be captured and presented
+    * in the HMD. Calling this function has the same effect on the source
+    * canvas as any other operation that uses its source image, and canvases
+    * created without preserveDrawingBuffer set to true will be cleared.
+    */
+  def submitFrame(pose: VRPose = ???): Unit = js.native
+}
+
+/**
+  * The VRDisplayCapabilities interface describes the capabilities of a VRDisplay.
+  * These are expected to be static per-device/per-user.
+  */
+@ScalaJSDefined
+trait VRDisplayCapabilities extends js.Object {
+  /** The hasPosition attribute MUST return whether the VRDisplay is capable of tracking its position. */
+  val hasPosition: Boolean
+  /** The hasOrientation attribute MUST return whether the VRDisplay is capable of tracking its orientation. */
+  val hasOrientation: Boolean
+  /** The hasExternalDisplay attribute MUST return whether the VRDisplay is separate
+    * from the device’s primary display. If presenting VR content will obscure other content on the device,
+    * this should be false. When false, the application should not attempt to
+    * mirror VR content or update non-VR UI because that content will not be visible.
+    */
+  val hasExternalDisplay: Boolean
+  /**
+    * The canPresent attribute MUST return whether the VRDisplay is capable of presenting content
+    * to an HMD or similar device. Can be used to indicate "magic window" devices that are capable
+    * of 6DoF tracking but for which VRDisplay.requestPresent() is not meaningful.
+    * If false then calls to VRDisplay.requestPresent() should always fail, and VRDisplay.getEyeParameters() should return NULL.
+    */
+  val canPresent: Boolean
+  /**
+    * Indicates the maximum length of the array that requestPresent() will accept. MUST be 1 if canPresent is true, 0 otherwise.
+    */
+  val maxLayers: Int
+}
+
+/**
+  * The VRFieldOfView interface represents a field of view, as given by 4 degrees describing the view from a center point.
+  */
+@ScalaJSDefined
+trait VRFieldOfView extends js.Object {
+  val upDegrees: Double
+  val rightDegrees: Double
+  val downDegrees: Double
+  val leftDegrees: Double
+}
+
+/**
+  * The VRPose interface represents a sensor’s state at a given timestamp.
+  */
+@ScalaJSDefined
+trait VRPose extends js.Object {
+  /**
+    * Monotonically increasing value that allows the author to determine if position state data been updated from the hardware. Since values are monotonically increasing, they can be compared to determine the ordering of updates, as newer values will always be greater than or equal to older values.
+    */
+  val timestamp: Double // DOMHighResTimeStamp
+  /**
+    * Position of the VRDisplay at timestamp as a 3D vector. Position is given in meters from an origin point, which is either the position the sensor was first read at or the position of the sensor at the point that resetPose() was last called. The coordinate system uses these axis definitions:
+    *
+    * Positive X is to the user’s right.
+    * Positive Y is up.
+    * Positive Z is behind the user.
+    * All positions are given relative to the identity orientation in sitting space. Transforming this point with VRStageParameters.sittingToStandingTransform converts this to standing space. MAY be NULL if the sensor is incapable of providing positional data. User agents MAY provide emulated position values through techniques such as neck modeling, but when doing so SHOULD report VRDisplayCapabilities.hasPosition as false. When not NULL MUST be a three-element array.
+    */
+  val position: Float32Array
+  /** Linear velocity of the sensor at timestamp meters per second. MAY be NULL if the sensor is incapable of providing linear velocity. When not NULL MUST be a three-element array.
+    */
+  val linearVelocity: Float32Array
+  /**
+    * Linear acceleration of the sensor at timestamp given in meters per second squared. MAY be NULL if the sensor is incapable of providing linear acceleration. When not NULL MUST be a three-element array.
+    */
+  val linearAcceleration: Float32Array
+  /**
+    * Orientation of the sensor at timestamp as a quaternion. The orientation yaw (rotation around the Y axis) is relative to the initial yaw of the sensor when it was first read or the yaw of the sensor at the point that resetPose() was last called. An orientation of [0, 0, 0, 1] is considered to be "forward". MAY be NULL if the sensor is incapable of providing orientation data. When not NULL MUST be a four-element array.
+    */
+  val orientation: Float32Array
+  /**
+    * Angular velocity of the sensor at timestamp given in radians per second. MAY be NULL if the sensor is incapable of providing angular velocity. When not NULL MUST be a three-element array.
+    */
+  val angularVelocity: Float32Array
+  /**
+    * Angular acceleration of the sensor at timestamp given in radians per second squared. MAY be NULL if the sensor is incapable of providing angular acceleration. When not NULL MUST be a three-element array.
+    */
+  val angularAcceleration: Float32Array
+}
+
+/**
+  * The VREyeParameters interface represents all the information required to correctly render a scene for a given eye.
+  */
+@ScalaJSDefined
+trait VREyeParameters extends js.Object {
+  /**
+    * Offset from the center point between the users eyes to the center of the eye in meters. This value SHOULD represent half of the user’s interpupillary distance (IPD), but MAY also represent the distance from the center point of the headset to the center point of the lens for the given eye. Values for the left eye MUST be negative; values for the right eye MUST be positive.
+    */
+  val offset: Float32Array
+  /**
+    * The current field of view for the eye, as the user adjusts her headset IPD.
+    */
+  val fieldOfView: VRFieldOfView
+  /**
+    * Describes the recommended render target width of each eye viewport, in pixels. If multiple eyes are rendered in a single render target, then the render target should be made large enough to fit both viewports. The renderWidth for the left eye and right eye MUST NOT overlap, and the renderWidth for the right eye MUST be to the right of the renderWidth for the left eye.
+    */
+  val renderWidth: Int
+  /**
+    * Describes the recommended render target height of each eye viewport, in pixels. If multiple eyes are rendered in a single render target, then the render target should be made large enough to fit both viewports. The renderWidth for the left eye and right eye MUST NOT overlap, and the renderWidth for the right eye MUST be to the right of the renderWidth for the left eye.
+    */
+  val renderHeight: Int
+}
+
+/**
+  * The VRStageParameters interface represents the values describing the the stage/play area for devices that support room-scale experiences.
+  */
+@ScalaJSDefined
+trait VRStageParameters extends js.Object {
+  /**
+    * The sittingToStandingTransform attribute is a 16-element array containing the components of a 4×4 transform matrix. This matrix transforms the sitting-space position returned by getPose()/getImmediatePose() to a standing-space position.
+    */
+  val sittingToStandingTransform: Float32Array
+  /**
+    * Width of the play-area bounds in meters. The bounds are defined as an axis-aligned rectangle on the floor. The center of the rectangle is at (0,0,0) in standing-space coordinates. These bounds are defined for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle.
+    */
+  val sizeX: Float
+  /**
+    * Depth of the play-area bounds in meters. The bounds are defined as an axis-aligned rectangle on the floor. The center of the rectangle is at (0,0,0) in standing-space coordinates. These bounds are defined for safety purposes. Content should not require the user to move beyond these bounds; however, it is possible for the user to ignore the bounds resulting in position values outside of this rectangle.
+    */
+  val sizeZ: Float
+}
+
+/**
+  * Navigator Interface extension
+  */
+@ScalaJSDefined
+trait Navigator extends js.Object {
+  /** Return a Promise which resolves to a list of available VRDisplays. */
+  def getVRDisplays(): Promise[js.Array[VRDisplay]]
+
+  /** activeVRDisplays includes every VRDisplay that is currently presenting. */
+  val activeVRDisplays: js.Array[VRDisplay] // FrozenArray
+}
+
+/**
+  * Window Interface extension
+  */
+@ScalaJSDefined
+trait Window extends js.Object {
+  /** A user agent MAY dispatch this event type to indicate that a VRDisplay has been connected. */
+  var onvrdisplayconnected: EventHandler
+  /** A user agent MAY dispatch this event type to indicate that a VRDisplay has been disconnected. */
+  var onvrdisplaydisconnected: EventHandler
+  /** A user agent MAY dispatch this event type to indicate that something has occured which suggests the VRDisplay should be presented to. For example, if the VRDisplay is capable of detecting when the user has put it on, this event SHOULD fire when they do so with the reason "mounted". */
+  var onvrdisplayactivate: EventHandler
+  /** A user agent MAY dispatch this event type to indicate that something has occured which suggests the VRDisplay should exit presentation. For example, if the VRDisplay is capable of detecting when the user has taken it off, this event SHOULD fire when they do so with the reason "unmounted". */
+  var onvrdisplaydeactivate: EventHandler
+  /** A user agent MUST dispatch this event type to indicate that a VRDisplay has begun or ended VR presentation. This event should not fire on subsequent calls to requestPresent() after the VRDisplay has already begun VR presentation. */
+  var onvrdisplaypresentchange: EventHandler
+}
+
+/**
+  * Gamepad Interface extension
+  */
+@ScalaJSDefined
+trait Gamepad extends js.Object {
+  /** Return the displayId for the associated VRDisplay. */
+  val displayId: Int
+}
+
+/**
+  * the VREye types, "left" ot "right"
+  */
+object VREye extends Enumeration {
+  type VREye = Value
+  val Left = Value("left")
+  val Right = Value("right")
+}
+
+/**
+  * the VRDisplayEventReason types
+  */
+object VRDisplayEventReason extends Enumeration {
+  type VRDisplayEventReason = Value
+  /** The page has been navigated to from a context that allows this page to begin presenting immediately, such as from another site that was already in VR presentation mode. */
+  val Navigation = Value("navigation")
+  /** The VRDisplay has detected that the user has put it on. */
+  val Mounted = Value("mounted")
+  /** The VRDisplay has detected that the user has taken it off. */
+  val Unmounted = Value("unmounted")
+}
+
+/**
+  * The VRDisplayEvent
+  */
+@js.native
+class VRDisplayEvent(eventInitDict: VRDisplayEventInit) extends Event {
+  /** The VRDisplay associated with this event. */
+  val display: VRDisplay = js.native
+  /** VRDisplayEventReason describing why this event has has been fired. */
+  val reason: String = js.native // VRDisplayEventReason see implicit
+}
+
+@ScalaJSDefined
+trait VRDisplayEventInit extends js.Object {
+  /** The VRDisplay associated with this event. */
+  val display: VRDisplay
+  /** VRDisplayEventReason describing why this event has has been fired. */
+  val reason: String // VRDisplayEventReason see implicit
+}
+
+object VRDisplayEventInit {
+  def apply(display: VRDisplay, reason: String): VRDisplayEventInit = {
+    js.Dynamic
+      .literal(display = display, reason = reason)
+      .asInstanceOf[VRDisplayEventInit]
+  }
+}
+
+

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
@@ -307,15 +307,6 @@ trait WindowWebVR extends js.Object {
 }
 
 /**
-  * Gamepad Interface extension
-  */
-@js.native
-trait GamepadWebVR extends js.Object {
-  /** Return the displayId for the associated VRDisplay. */
-  val displayId: Int = js.native
-}
-
-/**
   * the VREye types, "left" ot "right"
   */
 object VREye extends Enumeration {

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
@@ -70,7 +70,7 @@ trait VRDisplay extends EventTarget {
   def stageParameters: VRStageParameters = js.native
 
   /* Return the current VREyeParameters for the given eye. */
-  def getEyeParameters(whichEye: String): VREyeParameters = js.native
+  def getEyeParameters(whichEye: VREye): VREyeParameters = js.native
 
   /**
     * An identifier for this distinct VRDisplay. Used as an
@@ -318,12 +318,12 @@ trait WindowWebVR extends js.Object {
 }
 
 /**
-  * the VREye types, "left" ot "right"
+  * the VREye types, "left" or "right"
   */
-object VREye extends Enumeration {
-  type VREye = Value
-  val Left = Value("left")
-  val Right = Value("right")
+sealed class VREye(val whichEye: String)
+object VREye {
+  case object Left extends VREye("left")
+  case object Right extends VREye("right")
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
@@ -11,9 +11,8 @@ import org.scalajs.dom._
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
-import scala.scalajs.js.{Promise => _, _}
+import scala.scalajs.js.Promise
 import scala.scalajs.js.typedarray.Float32Array
-import scala.concurrent._
 import scala.language.implicitConversions
 
 
@@ -281,39 +280,39 @@ trait VRStageParameters extends js.Object {
 /**
   * Navigator Interface extension
   */
-@ScalaJSDefined
-trait Navigator extends js.Object {
+@js.native
+trait NavigatorWebVR extends js.Object {
   /** Return a Promise which resolves to a list of available VRDisplays. */
-  def getVRDisplays(): Promise[js.Array[VRDisplay]]
+  def getVRDisplays(): Promise[js.Array[VRDisplay]] = js.native
 
   /** activeVRDisplays includes every VRDisplay that is currently presenting. */
-  val activeVRDisplays: js.Array[VRDisplay] // FrozenArray
+  val activeVRDisplays: js.Array[VRDisplay] = js.native
 }
 
 /**
   * Window Interface extension
   */
-@ScalaJSDefined
-trait Window extends js.Object {
+@js.native
+trait WindowWebVR extends js.Object {
   /** A user agent MAY dispatch this event type to indicate that a VRDisplay has been connected. */
-  var onvrdisplayconnected: EventHandler
+  var onvrdisplayconnected: EventHandler = js.native
   /** A user agent MAY dispatch this event type to indicate that a VRDisplay has been disconnected. */
-  var onvrdisplaydisconnected: EventHandler
+  var onvrdisplaydisconnected: EventHandler = js.native
   /** A user agent MAY dispatch this event type to indicate that something has occured which suggests the VRDisplay should be presented to. For example, if the VRDisplay is capable of detecting when the user has put it on, this event SHOULD fire when they do so with the reason "mounted". */
-  var onvrdisplayactivate: EventHandler
+  var onvrdisplayactivate: EventHandler = js.native
   /** A user agent MAY dispatch this event type to indicate that something has occured which suggests the VRDisplay should exit presentation. For example, if the VRDisplay is capable of detecting when the user has taken it off, this event SHOULD fire when they do so with the reason "unmounted". */
-  var onvrdisplaydeactivate: EventHandler
+  var onvrdisplaydeactivate: EventHandler = js.native
   /** A user agent MUST dispatch this event type to indicate that a VRDisplay has begun or ended VR presentation. This event should not fire on subsequent calls to requestPresent() after the VRDisplay has already begun VR presentation. */
-  var onvrdisplaypresentchange: EventHandler
+  var onvrdisplaypresentchange: EventHandler = js.native
 }
 
 /**
   * Gamepad Interface extension
   */
-@ScalaJSDefined
-trait Gamepad extends js.Object {
+@js.native
+trait GamepadWebVR extends js.Object {
   /** Return the displayId for the associated VRDisplay. */
-  val displayId: Int
+  val displayId: Int = js.native
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/WebVR.scala
@@ -211,7 +211,12 @@ trait VRPose extends js.Object {
     * Positive X is to the user’s right.
     * Positive Y is up.
     * Positive Z is behind the user.
-    * All positions are given relative to the identity orientation in sitting space. Transforming this point with VRStageParameters.sittingToStandingTransform converts this to standing space. MAY be NULL if the sensor is incapable of providing positional data. User agents MAY provide emulated position values through techniques such as neck modeling, but when doing so SHOULD report VRDisplayCapabilities.hasPosition as false. When not NULL MUST be a three-element array.
+    * All positions are given relative to the identity orientation in sitting space.
+    * Transforming this point with VRStageParameters.sittingToStandingTransform converts
+    * this to standing space. MAY be NULL if the sensor is incapable of providing positional data.
+    * User agents MAY provide emulated position values through techniques such as neck modeling,
+    * but when doing so SHOULD report VRDisplayCapabilities.hasPosition as false.
+    * When not NULL MUST be a three-element array.
     */
   val position: Float32Array
   /** Linear velocity of the sensor at timestamp meters per second. MAY be NULL if the sensor is incapable of providing linear velocity. When not NULL MUST be a three-element array.
@@ -222,7 +227,13 @@ trait VRPose extends js.Object {
     */
   val linearAcceleration: Float32Array
   /**
-    * Orientation of the sensor at timestamp as a quaternion. The orientation yaw (rotation around the Y axis) is relative to the initial yaw of the sensor when it was first read or the yaw of the sensor at the point that resetPose() was last called. An orientation of [0, 0, 0, 1] is considered to be "forward". MAY be NULL if the sensor is incapable of providing orientation data. When not NULL MUST be a four-element array.
+    * Orientation of the sensor at timestamp as a quaternion.
+    * The orientation yaw (rotation around the Y axis) is relative to the initial yaw of
+    * the sensor when it was first read or the yaw of the sensor at the point that
+    * resetPose() was last called.
+    * An orientation of [0, 0, 0, 1] is considered to be "forward".
+    * MAY be NULL if the sensor is incapable of providing orientation data.
+    * When not NULL MUST be a four-element array.
     */
   val orientation: Float32Array
   /**

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/package.scala
@@ -3,8 +3,6 @@ package org.scalajs.dom.experimental
 
 import org.scalajs.dom.Event
 import org.scalajs.dom.experimental.offscreencanvas.OffscreenCanvas
-import org.scalajs.dom.experimental.webvr.VRDisplayEventReason.VRDisplayEventReason
-import org.scalajs.dom.experimental.webvr.VREye.VREye
 
 import language.implicitConversions
 import org.scalajs.dom.raw.HTMLCanvasElement
@@ -13,17 +11,11 @@ import scala.scalajs.js
 import scala.scalajs.js.{Any, |}
 
 /**
-  * WebVR API, Editor’s Draft, 27 July 2016.
+  * WebVR API, Editor’s Draft, 21 September 2016
   *
   * [[https://w3c.github.io/webvr/]]
   */
 package object webvr {
-
-  /** converts VREye type to its string representation, "left" or "right" */
-  implicit def VREyeToString(t: VREye): String = t.toString
-
-  /** converts VRDisplayEventReason type to its string representation */
-  implicit def VRDisplayEventReasonToString(t: VRDisplayEventReason): String = t.toString
 
   type VRSource = HTMLCanvasElement | OffscreenCanvas
 

--- a/src/main/scala/org/scalajs/dom/experimental/webvr/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webvr/package.scala
@@ -1,0 +1,33 @@
+package org.scalajs.dom.experimental
+
+
+import org.scalajs.dom.Event
+import org.scalajs.dom.experimental.offscreencanvas.OffscreenCanvas
+import org.scalajs.dom.experimental.webvr.VRDisplayEventReason.VRDisplayEventReason
+import org.scalajs.dom.experimental.webvr.VREye.VREye
+
+import language.implicitConversions
+import org.scalajs.dom.raw.HTMLCanvasElement
+
+import scala.scalajs.js
+import scala.scalajs.js.{Any, |}
+
+/**
+  * WebVR API, Editor’s Draft, 27 July 2016.
+  *
+  * [[https://w3c.github.io/webvr/]]
+  */
+package object webvr {
+
+  /** converts VREye type to its string representation, "left" or "right" */
+  implicit def VREyeToString(t: VREye): String = t.toString
+
+  /** converts VRDisplayEventReason type to its string representation */
+  implicit def VRDisplayEventReasonToString(t: VRDisplayEventReason): String = t.toString
+
+  type VRSource = HTMLCanvasElement | OffscreenCanvas
+
+  type EventHandler = js.Function1[Event, _]
+
+}
+

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -3588,6 +3588,22 @@ class Screen extends js.Object {
    * MDN
    */
   def pixelDepth: Int = js.native
+
+  /** The lockOrientation method locks the screen into the specified orientation.
+    * see [[https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation]]
+    * @param orientation The orientation into which to lock the screen. This is either a string or an array of strings.
+    *                    Passing several strings lets the screen rotate only in the selected orientations.
+    * @return Returns true if the orientation was authorized to be locked or false if the orientation locking was denied.
+    *         Note that the returns value doesn't indicate that the screen orientation is indeed locked: there may be a delay.
+    */
+  def lockOrientation(orientation: String | Array[String]): Boolean = js.native
+
+  /**
+    * The Screen.unlockOrientation method removes all the previous screen locks set by the page/app.
+    * see [[https://developer.mozilla.org/en-US/docs/Web/API/Screen/unlockOrientation]]
+    * @return Returns true if the orientation was successfully unlocked or false if the orientation couldn't be unlocked
+    */
+  def unlockOrientation(): Boolean = js.native
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -5390,6 +5390,23 @@ object Event extends js.Object {
 }
 
 /**
+  * The ImageBitmap interface represents a bitmap image which can be drawn to a <canvas> without undue latency.
+  * It can be created from a variety of source objects using the createImageBitmap() factory method.
+  * ImageBitmap provides an asynchronous and resource efficient pathway to prepare textures for rendering in WebGL.
+  *
+  * [[https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap]]
+  */
+@js.native
+trait ImageBitmap extends js.Object {
+  /** Is an unsigned long representing the height, in CSS pixels, of the ImageData. */
+  def width: Int = js.native
+  /** Is an unsigned long representing the width, in CSS pixels, of the ImageData. */
+  def height: Int = js.native
+  /** Disposes of all graphical resources associated with an ImageBitmap. */
+  def close(): Unit = js.native
+}
+
+/**
  * The ImageData interface represents the underlying pixel data of an area of a
  * &lt;canvas&gt; element. It is created using creators on the CanvasRenderingContext2D
  * object associated with the canvas createImageData() and getImageData()). It can

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -3589,6 +3589,17 @@ class Screen extends js.Object {
    */
   def pixelDepth: Int = js.native
 
+  /**
+    * The Screen.orientation property give the current orientation of the screen.
+    *
+    * [[https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation]]
+    *
+    * The return value is a string representing the orientation of the screen.
+    * It can be portrait-primary, portrait-secondary, landscape-primary,
+    * landscape-secondary (See lockOrientation for more info about those values).
+    */
+  def orientation: String = js.native
+
   /** The lockOrientation method locks the screen into the specified orientation.
     * see [[https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation]]
     * @param orientation The orientation into which to lock the screen. This is either a string or an array of strings.

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -9,6 +9,8 @@
  */
 package org.scalajs.dom.raw
 
+import org.scalajs.dom.experimental.webvr.{NavigatorWebVR, WindowWebVR}
+
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.ArrayBuffer
 import scala.scalajs.js.|
@@ -490,7 +492,7 @@ trait WindowTimers extends WindowTimersExtension {
 @js.native
 class Navigator
     extends NavigatorID with NavigatorOnLine with NavigatorContentUtils
-    with NavigatorGeolocation with NavigatorStorageUtils with NavigatorLanguage
+    with NavigatorGeolocation with NavigatorStorageUtils with NavigatorLanguage with NavigatorWebVR
 
 @js.native
 trait NodeSelector extends js.Object {
@@ -1720,7 +1722,7 @@ trait WindowSessionStorage extends js.Object {
 class Window
     extends EventTarget with WindowLocalStorage with WindowSessionStorage
     with WindowTimers with WindowBase64 with IDBEnvironment
-    with WindowConsole {
+    with WindowConsole with WindowWebVR {
   var ondragend: js.Function1[DragEvent, _] = js.native
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -9,6 +9,7 @@
  */
 package org.scalajs.dom.raw
 
+import org.scalajs.dom.experimental.screenorientation.ScreenOrientation
 import org.scalajs.dom.experimental.webvr.{NavigatorWebVR, WindowWebVR}
 
 import scala.scalajs.js


### PR DESCRIPTION
Facade to WebVR API (draft API).
Includes interfaces to OffscreenCanvas and ImageBitmap
