### PR TITLE
Add toHex to Color

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -42,6 +42,8 @@ class EasySeq[T](jsLength: Int, jsApply: Int => T) extends Seq[T] {
 case class Color(r: Int, g: Int, b: Int) {
   override def toString() = s"rgb($r, $g, $b)"
 
+  def toHex: String = f"#$r%02x$g%02x$b%02x"
+
   def *(c: Color) = Color(r * c.r, g * c.g, b * c.b)
 
   def +(c: Color) = Color(r + c.r, g + c.g, b + c.b)


### PR DESCRIPTION
The ability to get a hex representation is crucial when working with `<input type="color" ... />`: https://scalafiddle.io/sf/NfAZ1AU/6