### PR TITLE
Fix SVGTextContentElement to use correct return types

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -1895,15 +1895,15 @@ abstract class SVGTextContentElement
 
   def getExtentOfChar(charnum: Int): SVGRect = js.native
 
-  def getComputedTextLength(): Int = js.native
+  def getComputedTextLength(): Double = js.native
 
-  def getSubStringLength(charnum: Int, nchars: Int): Int = js.native
+  def getSubStringLength(charnum: Int, nchars: Int): Double = js.native
 
   def selectSubString(charnum: Int, nchars: Int): Unit = js.native
 
   def getNumberOfChars(): Int = js.native
 
-  def getRotationOfChar(charnum: Int): Int = js.native
+  def getRotationOfChar(charnum: Int): Double = js.native
 
   def getEndPositionOfChar(charnum: Int): SVGPoint = js.native
 }

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1155,6 +1155,14 @@ abstract class Node extends EventTarget {
   def compareDocumentPosition(other: Node): Int = js.native
 
   /**
+   * Returns a Boolean value indicating whether a node is a descendant of a given node
+   * or not.
+   *
+   * MDN
+   */
+  def contains(other: Node): Boolean = js.native
+
+  /**
    * Puts the specified node and all of its subtree into a "normalized" form. In a
    * normalized subtree, no text nodes in the subtree are empty and there are no adjacent
    * text nodes.


### PR DESCRIPTION
Reference : https://www.w3.org/TR/SVG/text.html#InterfaceSVGTextContentElement
MDN : https://developer.mozilla.org/en-US/docs/Web/API/SVGTextContentElement