### PR TITLE
Deprecate some non-standard and obsolete types and fields.

### DIFF
--- a/src/main/scala/org/scalajs/dom/html.scala
+++ b/src/main/scala/org/scalajs/dom/html.scala
@@ -5,12 +5,15 @@ package org.scalajs.dom
  */
 object html {
   type Anchor = raw.HTMLAnchorElement
+  @deprecated("Obsolete.", "HTML 5")
   type Applet = raw.HTMLAppletElement
   type Audio = raw.HTMLAudioElement
   type Area = raw.HTMLAreaElement
   type AreasCollection = raw.HTMLAreasCollection
   type Base = raw.HTMLBaseElement
+  @deprecated("Obsolete.", "DOM Level 2")
   type BaseFont = raw.HTMLBaseFontElement
+  @deprecated("Non standard.", "forever")
   type BGSound = raw.HTMLBGSoundElement
   type BlockElement = raw.HTMLBlockElement
   type Body = raw.HTMLBodyElement
@@ -20,6 +23,7 @@ object html {
   type Collection = raw.HTMLCollection
   type DataList = raw.HTMLDataListElement
   type DD = raw.HTMLDDElement
+  @deprecated("Obsolete.", "HTML 4")
   type Directory = raw.HTMLDirectoryElement
   type Div = raw.HTMLDivElement
   type DList = raw.HTMLDListElement
@@ -28,9 +32,12 @@ object html {
   type Element = raw.HTMLElement
   type Embed = raw.HTMLEmbedElement
   type FieldSet = raw.HTMLFieldSetElement
+  @deprecated("Obsolete.", "HTML 4.01")
   type Font = raw.HTMLFontElement
   type Form = raw.HTMLFormElement
+  @deprecated("Obsolete.", "HTML 5")
   type Frame = raw.HTMLFrameElement
+  @deprecated("Obsolete.", "HTML 5")
   type FrameSet = raw.HTMLFrameSetElement
   type Head = raw.HTMLHeadElement
   type Heading = raw.HTMLHeadingElement
@@ -39,18 +46,21 @@ object html {
   type IFrame = raw.HTMLIFrameElement
   type Image = raw.HTMLImageElement
   type Input = raw.HTMLInputElement
+  @deprecated("Obsolete.", "HTML 4.01")
   type IsIndex = raw.HTMLIsIndexElement
   type Label = raw.HTMLLabelElement
   type Legend = raw.HTMLLegendElement
   type LI = raw.HTMLLIElement
   type Link = raw.HTMLLinkElement
   type Map = raw.HTMLMapElement
+  @deprecated("Obsolete.", "HTML 5")
   type Marquee = raw.HTMLMarqueeElement
   type Media = raw.HTMLMediaElement
   @inline def Media = raw.HTMLMediaElement
   type Menu = raw.HTMLMenuElement
   type Meta = raw.HTMLMetaElement
   type Mod = raw.HTMLModElement
+  @deprecated("Obsolete.", "HTML 3.2")
   type NextIdElement = raw.HTMLNextIdElement
   type Object = raw.HTMLObjectElement
   type OList = raw.HTMLOListElement

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -210,6 +210,7 @@ abstract class HTMLDocument extends Document {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   def applets: HTMLCollection = js.native
 
   /**
@@ -220,14 +221,14 @@ abstract class HTMLDocument extends Document {
   def images: HTMLCollection = js.native
 
   /**
-   * Returns the current value of the current range for a formating command.
+   * Returns the current value of the current range for a formatting command.
    *
    * MDN
    */
   def queryCommandValue(commandId: String): String = js.native
 
   /**
-   * Returns true if the formating command is in an indeterminate state on the current
+   * Returns true if the formatting command is in an indeterminate state on the current
    * range.
    *
    * MDN
@@ -251,14 +252,14 @@ abstract class HTMLDocument extends Document {
   def queryCommandSupported(commandId: String): Boolean = js.native
 
   /**
-   * Returns true if the formating command can be executed on the current range.
+   * Returns true if the formatting command can be executed on the current range.
    *
    * MDN
    */
   def queryCommandEnabled(commandId: String): Boolean = js.native
 
   /**
-   * Returns true if the formating command has been executed on the current range.
+   * Returns true if the formatting command has been executed on the current range.
    *
    * MDN
    */
@@ -562,6 +563,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var width: String = js.native
 
   /**
@@ -570,6 +572,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var cellSpacing: String = js.native
 
   /**
@@ -592,6 +595,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var frame: String = js.native
 
   /**
@@ -612,6 +616,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var rules: String = js.native
 
   /**
@@ -620,6 +625,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var summary: String = js.native
 
   /**
@@ -663,6 +669,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -672,6 +679,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var cellPadding: String = js.native
 
   /**
@@ -680,6 +688,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var border: String = js.native
 
   /**
@@ -798,6 +807,7 @@ abstract class HTMLBaseElement extends HTMLElement {
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 3.2")
 trait HTMLNextIdElement extends HTMLElement {
   var n: String = js.native
 }
@@ -819,6 +829,7 @@ abstract class HTMLParagraphElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 }
 
@@ -830,6 +841,7 @@ trait HTMLAreasCollection extends HTMLCollection {
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 5")
 abstract class HTMLAppletElement extends HTMLElement {
   var width: Double = js.native
   var codeType: String = js.native
@@ -1069,6 +1081,7 @@ abstract class HTMLMetaElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var scheme: String = js.native
   var charset: String = js.native
 }
@@ -1132,6 +1145,7 @@ abstract class HTMLLinkElement extends HTMLElement with LinkStyle {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var charset: String = js.native
 
   /**
@@ -1143,6 +1157,7 @@ abstract class HTMLLinkElement extends HTMLElement with LinkStyle {
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 4.01")
 abstract class HTMLFontElement extends HTMLElement {
   var face: String = js.native
 }
@@ -1163,7 +1178,10 @@ abstract class HTMLTableCaptionElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var vAlign: String = js.native
 }
 
@@ -1292,6 +1310,7 @@ abstract class HTMLCollection extends DOMList[Element] {
    *
    * MDN
    */
+  @deprecated("Non-standard.", "forever")
   def item(nameOrIndex: js.Any = js.native,
       optionalIndex: js.Any = js.native): Element = js.native
 
@@ -1323,6 +1342,8 @@ abstract class HTMLImageElement extends HTMLElement {
    * MDN
    */
   var width: Int = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var vspace: Int = js.native
 
   /**
@@ -1344,6 +1365,7 @@ abstract class HTMLImageElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -1366,6 +1388,8 @@ abstract class HTMLImageElement extends HTMLElement {
    * MDN
    */
   var naturalWidth: Int = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var name: String = js.native
 
   /**
@@ -1381,6 +1405,7 @@ abstract class HTMLImageElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var border: String = js.native
 
   /**
@@ -1388,6 +1413,7 @@ abstract class HTMLImageElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var hspace: Int = js.native
 
   /**
@@ -1395,7 +1421,9 @@ abstract class HTMLImageElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var longDesc: String = js.native
+
   var href: String = js.native
 
   /**
@@ -1519,6 +1547,7 @@ abstract class HTMLAreaElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var noHref: Boolean = js.native
 
   /**
@@ -1708,6 +1737,8 @@ abstract class HTMLScriptElement extends HTMLElement {
    * MDN
    */
   var src: String = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var htmlFor: String = js.native
 
   /**
@@ -1781,6 +1812,7 @@ abstract class HTMLTableRowElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
   var borderColorLight: js.Any = js.native
 
@@ -1831,10 +1863,12 @@ abstract class HTMLHtmlElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var version: String = js.native
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 5")
 abstract class HTMLFrameElement extends HTMLElement with GetSVGDocument {
   var width: js.Any = js.native
   var scrolling: String = js.native
@@ -1897,6 +1931,7 @@ abstract class HTMLTableHeaderCellElement extends HTMLTableCellElement
 abstract class HTMLDListElement extends HTMLElement
 
 @js.native
+@deprecated("Obsolete.", "HTML 5")
 abstract class HTMLFrameSetElement extends HTMLElement {
   var ononline: js.Function1[Event, _] = js.native
   var borderColor: js.Any = js.native
@@ -1953,6 +1988,7 @@ abstract class HTMLLegendElement extends HTMLElement {
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 4")
 abstract class HTMLDirectoryElement extends HTMLElement
 
 /**
@@ -2035,6 +2071,7 @@ abstract class HTMLIFrameElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var longDesc: String = js.native
   var security: js.Any = js.native
   var onload: js.Function1[Event, _] = js.native
@@ -2074,6 +2111,8 @@ abstract class HTMLBodyElement extends HTMLElement {
    * MDN
    */
   var onmessage: js.Function1[MessageEvent, _] = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var text: js.Any = js.native
 
   /**
@@ -2093,7 +2132,11 @@ abstract class HTMLBodyElement extends HTMLElement {
    * MDN
    */
   var onresize: js.Function1[UIEvent, _] = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var link: js.Any = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var aLink: js.Any = js.native
 
   /**
@@ -2103,6 +2146,8 @@ abstract class HTMLBodyElement extends HTMLElement {
    * MDN
    */
   var onafterprint: js.Function1[Event, _] = js.native
+
+  @deprecated("Obsolete.", "HTML 5")
   var vLink: js.Any = js.native
 
   /**
@@ -2145,6 +2190,8 @@ abstract class HTMLBodyElement extends HTMLElement {
    * MDN
    */
   var onload: js.Function1[Event, _] = js.native
+
+  @deprecated("Non standard.", "forever")
   var rightMargin: js.Any = js.native
 
   /**
@@ -2154,6 +2201,8 @@ abstract class HTMLBodyElement extends HTMLElement {
    * MDN
    */
   var onbeforeunload: js.Function1[BeforeUnloadEvent, _] = js.native
+
+  @deprecated("Non standard.", "forever")
   var leftMargin: js.Any = js.native
 
   /**
@@ -2192,6 +2241,7 @@ abstract class HTMLTableSectionElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -2659,6 +2709,7 @@ abstract class HTMLAnchorElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var coords: String = js.native
 
   /**
@@ -2696,6 +2747,7 @@ abstract class HTMLAnchorElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var name: String = js.native
 
   /**
@@ -2742,6 +2794,7 @@ abstract class HTMLAnchorElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var rev: String = js.native
 
   /**
@@ -2749,6 +2802,7 @@ abstract class HTMLAnchorElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var shape: String = js.native
   var `type`: String = js.native
   var mimeType: String = js.native
@@ -2794,6 +2848,7 @@ abstract class HTMLParamElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var `type`: String = js.native
 
   /**
@@ -2802,6 +2857,7 @@ abstract class HTMLParamElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var valueType: String = js.native
 }
 
@@ -2821,6 +2877,7 @@ abstract class HTMLPreElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var width: Int = js.native
 }
 
@@ -2963,6 +3020,7 @@ abstract class HTMLTableCellElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var width: Int = js.native
 
   /**
@@ -2988,6 +3046,7 @@ abstract class HTMLTableCellElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -3004,6 +3063,7 @@ abstract class HTMLTableCellElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var axis: String = js.native
 
   /**
@@ -3012,6 +3072,7 @@ abstract class HTMLTableCellElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var height: js.Any = js.native
 
   /**
@@ -3020,6 +3081,7 @@ abstract class HTMLTableCellElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var noWrap: Boolean = js.native
 
   /**
@@ -3039,6 +3101,7 @@ abstract class HTMLTableCellElement
  * MDN
  */
 @js.native
+@deprecated("Obsolete.", "DOM Level 2")
 abstract class HTMLBaseFontElement extends HTMLElement {
 
   /**
@@ -3292,6 +3355,8 @@ abstract class HTMLModElement extends HTMLElement {
 @js.native
 abstract class HTMLTableColElement
     extends HTMLElement with HTMLTableAlignment {
+
+  @deprecated("Obsolete.", "HTML 5")
   var width: js.Any = js.native
 
   /**
@@ -3299,6 +3364,7 @@ abstract class HTMLTableColElement
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -3312,8 +3378,11 @@ abstract class HTMLTableColElement
 
 @js.native
 trait HTMLTableAlignment extends js.Object {
+  @deprecated("Obsolete.", "HTML 5")
   var ch: String = js.native
+  @deprecated("Obsolete.", "HTML 5")
   var vAlign: String = js.native
+  @deprecated("Obsolete.", "HTML 5")
   var chOff: String = js.native
 }
 
@@ -3344,6 +3413,7 @@ abstract class HTMLDivElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 }
 
@@ -3361,6 +3431,7 @@ abstract class HTMLBRElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var clear: String = js.native
 }
 
@@ -3656,6 +3727,8 @@ abstract class HTMLDTElement extends HTMLElement {
  */
 @js.native
 abstract class HTMLFieldSetElement extends HTMLElement {
+
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 
   /**
@@ -3719,6 +3792,7 @@ abstract class HTMLFieldSetElement extends HTMLElement {
 }
 
 @js.native
+@deprecated("Non standard.", "forever")
 abstract class HTMLBGSoundElement extends HTMLElement {
   var balance: js.Any = js.native
   var volume: js.Any = js.native
@@ -3993,6 +4067,7 @@ abstract class HTMLElement extends Element {
  */
 @js.native
 abstract class HTMLHRElement extends HTMLElement {
+  @deprecated("Obsolete.", "HTML 5")
   var width: Double = js.native
 
   /**
@@ -4001,6 +4076,7 @@ abstract class HTMLHRElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 }
 
@@ -4028,6 +4104,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var codeType: String = js.native
   var `object`: Object = js.native
 
@@ -4044,6 +4121,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var code: String = js.native
 
   /**
@@ -4052,6 +4130,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var archive: String = js.native
 
   /**
@@ -4060,6 +4139,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var standby: String = js.native
   var alt: String = js.native
   var classid: String = js.native
@@ -4109,6 +4189,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var codeBase: String = js.native
 
   /**
@@ -4117,6 +4198,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var declare: Boolean = js.native
   var `type`: String = js.native
   var BaseHref: String = js.native
@@ -4232,6 +4314,7 @@ abstract class HTMLOptGroupElement extends HTMLElement {
  * MDN
  */
 @js.native
+@deprecated("Obsolete.", "HTML 4.01")
 abstract class HTMLIsIndexElement extends HTMLElement {
 
   /**
@@ -4378,6 +4461,7 @@ abstract class HTMLTrackElement extends HTMLElement {
 }
 
 @js.native
+@deprecated("Obsolete.", "HTML 5")
 abstract class HTMLMarqueeElement extends HTMLElement {
   var width: String = js.native
   var onbounce: js.Function1[Event, _] = js.native
@@ -4423,6 +4507,7 @@ abstract class HTMLHeadElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var profile: String = js.native
 }
 
@@ -4441,6 +4526,7 @@ abstract class HTMLHeadingElement extends HTMLElement {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "HTML 5")
   var align: String = js.native
 }
 

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -262,6 +262,7 @@ class TreeWalker extends js.Object {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "WHATWG DOM")
   def expandEntityReferences: Boolean = js.native
 
   /**
@@ -1657,6 +1658,7 @@ class NodeIterator extends js.Object {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "WHATWG DOM")
   def expandEntityReferences: Boolean = js.native
 
   /**
@@ -5344,6 +5346,7 @@ class Event extends js.Object {
 
   def `type`: String = js.native
 
+  @deprecated("Non standard.", "forever")
   def srcElement: Element = js.native
 
   /**
@@ -6688,8 +6691,10 @@ trait AudioTrackList extends EventTarget with DOMList[AudioTrack] {
 
 @js.native
 trait WindowTimersExtension extends js.Object {
+  @deprecated("Non standard.", "forever")
   def clearImmediate(handle: Int): Unit = js.native
 
+  @deprecated("Non standard.", "forever")
   def setImmediate(handler: js.Function0[Any]): Int = js.native
 }
 
@@ -6728,6 +6733,7 @@ trait AnimationEvent extends Event {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initAnimationEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, animationNameArg: String,
       elapsedTimeArg: Int): Unit = js.native


### PR DESCRIPTION
I had to turn off fatal warnings because the type aliases refer to the deprecated types. It might be better to remove the type aliases entirely, or even skip deprecation and just remove the offending types and fields immediately.

See:
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bgsound
* https://msdn.microsoft.com/en-us/library/windows/apps/hh965347.aspx
* https://developer.mozilla.org/en-US/docs/Web/API/window/setImmediate
* https://developer.mozilla.org/en-US/docs/Web/API/Window/clearImmediate
* https://developer.mozilla.org/en/docs/Web/API/Event/srcElement
* https://msdn.microsoft.com/en-us/library/hh869721(v=vs.85).aspx
* https://www.w3.org/TR/html5/obsolete.html
* https://developer.mozilla.org/en-US/docs/Web/API/HTMLFontElement