### PR TITLE
Deprecate some non-standard and obsolete types and fields.

### DIFF
--- a/src/main/scala/org/scalajs/dom/package.scala
+++ b/src/main/scala/org/scalajs/dom/package.scala
@@ -114,7 +114,9 @@ package object dom {
   type MessagePort = raw.MessagePort
   type ModifierKeyEvent = raw.ModifierKeyEvent
   type MouseEvent = raw.MouseEvent
+  @deprecated("Obsolete.", "WHATWG DOM")
   type MutationEvent = raw.MutationEvent
+  @deprecated("Obsolete.", "WHATWG DOM")
   lazy val MutationEvent: raw.MutationEvent.type = raw.MutationEvent
   type MutationObserver = raw.MutationObserver
   type MutationObserverInit = raw.MutationObserverInit

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -440,6 +440,7 @@ class CompositionEvent extends UIEvent {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initCompositionEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, dataArg: String,
       locale: String): Unit = js.native
@@ -1385,6 +1386,7 @@ class MouseEvent extends UIEvent with ModifierKeyEvent {
    */
   def clientX: Double = js.native
 
+  @deprecated("Non-standard", "forever")
   def initMouseEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, detailArg: Int, screenXArg: Int,
       screenYArg: Int, clientXArg: Int, clientYArg: Int, ctrlKeyArg: Boolean,
@@ -2643,6 +2645,7 @@ class KeyboardEvent extends UIEvent with ModifierKeyEvent {
    */
   def getModifierState(keyArg: String): Boolean = js.native
 
+  @deprecated("Non-standard", "forever")
   def initKeyboardEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, keyArg: String,
       locationArg: Int, modifiersListArg: String, repeat: Boolean,
@@ -2988,6 +2991,7 @@ class MessageEvent extends Event {
    */
   def data: Any = js.native
 
+  @deprecated("Non-standard", "forever")
   def initMessageEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, dataArg: js.Any, originArg: String,
       lastEventIdArg: String, sourceArg: Window): Unit = js.native
@@ -3891,6 +3895,7 @@ class FocusEvent extends UIEvent {
    */
   def relatedTarget: EventTarget = js.native
 
+  @deprecated("Non-standard", "forever")
   def initFocusEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, detailArg: Int,
       relatedTargetArg: EventTarget): Unit = js.native
@@ -4175,17 +4180,21 @@ class Storage extends js.Object {
 abstract class DocumentType extends Node {
   def name: String = js.native
 
+  @deprecated("Obsolete.", "WHATWG DOM")
   def notations: NamedNodeMap = js.native
 
   def systemId: String = js.native
 
+  @deprecated("Obsolete.", "WHATWG DOM")
   def internalSubset: String = js.native
 
+  @deprecated("Obsolete.", "WHATWG DOM")
   def entities: NamedNodeMap = js.native
 
   def publicId: String = js.native
 }
 
+@deprecated("Obsolete.", "WHATWG DOM")
 @js.native
 class MutationEvent extends Event {
   def newValue: String = js.native
@@ -4204,6 +4213,7 @@ class MutationEvent extends Event {
       attrChangeArg: Int): Unit = js.native
 }
 
+@deprecated("Obsolete.", "WHATWG DOM")
 @js.native
 object MutationEvent extends js.Object {
   val MODIFICATION: Int = js.native
@@ -4431,6 +4441,7 @@ trait MutationRecord extends js.Object {
 trait DragEvent extends MouseEvent {
   def dataTransfer: DataTransfer = js.native
 
+  @deprecated("Non-standard", "forever")
   def initDragEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, detailArg: Int, screenXArg: Int,
       screenYArg: Int, clientXArg: Int, clientYArg: Int, ctrlKeyArg: Boolean,
@@ -4923,6 +4934,7 @@ class WheelEvent extends MouseEvent {
    */
   def deltaY: Double = js.native
 
+  @deprecated("Non-standard", "forever")
   def initWheelEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, detailArg: Int, screenXArg: Int,
       screenYArg: Int, clientXArg: Int, clientYArg: Int, buttonArg: Int,
@@ -4930,6 +4942,7 @@ class WheelEvent extends MouseEvent {
       deltaXArg: Double, deltaYArg: Double, deltaZArg: Double,
       deltaMode: Int): Unit = js.native
 
+  @deprecated("Non-standard", "forever")
   def getCurrentPoint(element: Element): Unit = js.native
 }
 
@@ -5344,6 +5357,7 @@ class Event extends js.Object {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initEvent(eventTypeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean): Unit = js.native
 
@@ -5842,6 +5856,7 @@ class StorageEvent extends Event {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initStorageEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, keyArg: String, oldValueArg: js.Any,
       newValueArg: js.Any, urlArg: String,
@@ -5933,6 +5948,7 @@ class DOMException extends js.Object {
    *
    * MDN
    */
+  @deprecated("Obsolete.", "DOM4")
   def code: Int = js.native
 
   def message: String = js.native
@@ -6091,6 +6107,7 @@ trait ErrorEvent extends Event {
    */
   def message: String = js.native
 
+  @deprecated("Non-standard", "forever")
   def initErrorEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, messageArg: String, filenameArg: String,
       linenoArg: Int): Unit = js.native
@@ -6171,6 +6188,7 @@ trait TransitionEvent extends Event {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initTransitionEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, propertyNameArg: String,
       elapsedTimeArg: Int): Unit = js.native
@@ -6267,6 +6285,7 @@ trait CloseEvent extends Event {
    */
   def code: Int = js.native
 
+  @deprecated("Non-standard", "forever")
   def initCloseEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, wasCleanArg: Boolean, codeArg: Int,
       reasonArg: String): Unit = js.native
@@ -6520,6 +6539,7 @@ trait ProgressEvent extends Event {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def initProgressEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, lengthComputableArg: Boolean, loadedArg: Double,
       totalArg: Double): Unit = js.native
@@ -6559,6 +6579,7 @@ abstract class File extends Blob {
    *
    * MDN
    */
+  @deprecated("Non-standard", "forever")
   def lastModifiedDate: js.Any = js.native
 
   /**
@@ -7135,6 +7156,7 @@ object ApplicationCache extends js.Object {
 trait PopStateEvent extends Event {
   def state: js.Any = js.native
 
+  @deprecated("Non-standard", "forever")
   def initPopStateEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, stateArg: js.Any): Unit = js.native
 }


### PR DESCRIPTION
See:

* https://w3c.github.io/uievents/#interface-compositionevent
* https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent
* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent
* https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent
* https://w3c.github.io/uievents/#interface-focusevent
* https://dom.spec.whatwg.org/#documenttype
* https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Mutation_events
* https://w3c.github.io/html/editing.html#the-dragevent-interface
* https://w3c.github.io/uievents/#interface-uievent
* https://w3c.github.io/uievents/#interface-wheelevent
* https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent
* https://dom.spec.whatwg.org/#dom-event-initevent
* https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface
* https://developer.mozilla.org/en-US/docs/Web/API/DOMException
* https://www.w3.org/TR/dom/#dfn-DOMException
* https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
* https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent/initTransitionEvent
* https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/initCloseEvent
* https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/initProgressEvent
* https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate
* https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache
* https://html.spec.whatwg.org/#popstateevent