### PR TITLE
HTMLTableElement.deleteRow() doesn’t have a default value.

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -698,7 +698,7 @@ abstract class HTMLTableElement extends HTMLElement {
    *
    * MDN
    */
-  def deleteRow(index: Int = js.native): Unit = js.native
+  def deleteRow(index: Int): Unit = js.native
 
   def createTBody(): HTMLElement = js.native
 


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/tables.html#the-table-element:concept-element-dom