### PR TITLE
Deprecate KeyboardEvent#key since it's not supported in safari

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2638,7 +2638,10 @@ class KeyboardEvent extends UIEvent with ModifierKeyEvent {
    * the detail.
    *
    * MDN
+   * 
+   * NOT supported in Safari
    */
+  @deprecated("Not yet supported in Safari")
   def key: String = js.native
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2641,7 +2641,7 @@ class KeyboardEvent extends UIEvent with ModifierKeyEvent {
    * 
    * NOT supported in Safari
    */
-  @deprecated("Not yet supported in Safari")
+  @deprecated("Compatibility", "Not yet supported in Safari")
   def key: String = js.native
 
   /**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

This just bit me; so far, the rule I've been going by is that only things "supported in all major browsers" should be available by default, and `key` isn't supported by safari

By deprecating this, we nudge people away from it and hopefully they'll start using `KeyboardEvent#keyCode`, which you can compare against `org.scalajs.dom.ext.KeyCode.*`. While `keyCode` is deprecated, it's the only one I found that works on all browsers =/

- [charCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode) also works on all browsers but is also deprecated/nonstandard
- [keyIdentifier](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier) doesn't work on firefox/IE and is also deprecated/nonstandard
- [code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) doesn't work in IE/safari

I don't know whether this is the right thing to do here, but it seems to me like the least-bad of all the options. If browsers start *actually* dropping support for `keyCode`, we may need to do something else, but we'll cross that bridge when we get to it