### PR TITLE
Updated misleading comments about which constant to reference.

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebGL.scala
@@ -631,76 +631,76 @@ object WebGLRenderingContext {
   /** Identifies texture unit 7. This texture unit is guaranteed to exist. */
   final val TEXTURE7 = 0x84C7
 
-  /** Identifies texture unit 8. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 8. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE8 = 0x84C8
 
-  /** Identifies texture unit 9. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 9. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE9 = 0x84C9
 
-  /** Identifies texture unit 10. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 10. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE10 = 0x84CA
 
-  /** Identifies texture unit 11. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 11. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE11 = 0x84CB
 
-  /** Identifies texture unit 12. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 12. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE12 = 0x84CC
 
-  /** Identifies texture unit 13. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 13. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE13 = 0x84CD
 
-  /** Identifies texture unit 14. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 14. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE14 = 0x84CE
 
-  /** Identifies texture unit 15. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 15. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE15 = 0x84CF
 
-  /** Identifies texture unit 16. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 16. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE16 = 0x84D0
 
-  /** Identifies texture unit 17. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 17. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE17 = 0x84D1
 
-  /** Identifies texture unit 18. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 18. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE18 = 0x84D2
 
-  /** Identifies texture unit 19. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 19. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE19 = 0x84D3
 
-  /** Identifies texture unit 20. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 20. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE20 = 0x84D4
 
-  /** Identifies texture unit 21. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 21. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE21 = 0x84D5
 
-  /** Identifies texture unit 22. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 22. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE22 = 0x84D6
 
-  /** Identifies texture unit 23. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 23. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE23 = 0x84D7
 
-  /** Identifies texture unit 24. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 24. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE24 = 0x84D8
 
-  /** Identifies texture unit 25. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 25. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE25 = 0x84D9
 
-  /** Identifies texture unit 26. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 26. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE26 = 0x84DA
 
-  /** Identifies texture unit 27. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 27. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE27 = 0x84DB
 
-  /** Identifies texture unit 28. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 28. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE28 = 0x84DC
 
-  /** Identifies texture unit 29. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 29. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE29 = 0x84DD
 
-  /** Identifies texture unit 30. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 30. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE30 = 0x84DE
 
-  /** Identifies texture unit 31. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_UNITS before using it. */
+  /** Identifies texture unit 31. This texture unit ''may not exist in a given implementation''. You should examine MAX_COMBINED_TEXTURE_IMAGE_UNITS before using it. */
   final val TEXTURE31 = 0x84DF
 
   /** The currently active texture unit. */
@@ -892,7 +892,7 @@ class WebGLRenderingContext extends js.Object {
   /**
    * Selects the active texture unit.
    *
-   * @param texture  an integer specifying the texture unit to make active. Must be in 0 .. MAX_COMBINED_TEXTURE_UNITS-1
+   * @param texture  an integer specifying the texture unit to make active. Must be in 0 .. MAX_COMBINED_TEXTURE_IMAGE_UNITS-1
    */
   def activeTexture(texture: Int): Unit = js.native
 


### PR DESCRIPTION
I think this is correct, but in any event the original constant in the comments does not exist.