### PR TITLE
Upgrade to Scala.js 0.6.15.

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rewrites = ["https://gist.githubusercontent.com/sjrd/ef8bb7c52be1451b3a3b9bab6a187549/raw/0b1d451d266bce20921bbff3a74722610d604509/ScalaJSRewrites.scala"]
+imports.organize = false
+imports.removeUnused = false

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,0 @@
-rewrites = ["https://gist.githubusercontent.com/sjrd/ef8bb7c52be1451b3a3b9bab6a187549/raw/0b1d451d266bce20921bbff3a74722610d604509/ScalaJSRewrites.scala"]
-imports.organize = false
-imports.removeUnused = false

--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,6 @@ scalacOptions ++= {
   }
 }
 
-// Temporarily disregard @JSGlobal warnings of Scala.js 0.6.15
-scalacOptions += "-P:scalajs:suppressMissingJSGlobalDeprecations"
-
 scmInfo := Some(ScmInfo(
     url("https://github.com/scala-js/scala-js-dom"),
     "scm:git:git@github.com:scala-js/scala-js-dom.git",

--- a/build.sbt
+++ b/build.sbt
@@ -83,8 +83,4 @@ lazy val readme = ScalatexReadme(
 lazy val example = project.
   enablePlugins(ScalaJSPlugin).
   settings(commonSettings: _*).
-  settings(
-    // Temporarily disregard @JSExport-on-object warnings of Scala.js 0.6.15
-    scalacOptions += "-P:scalajs:suppressExportDeprecations"
-  ).
   dependsOn(root)

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,9 @@ scalacOptions ++= {
   }
 }
 
+// Temporarily disregard @JSGlobal warnings of Scala.js 0.6.15
+scalacOptions += "-P:scalajs:suppressMissingJSGlobalDeprecations"
+
 scmInfo := Some(ScmInfo(
     url("https://github.com/scala-js/scala-js-dom"),
     "scm:git:git@github.com:scala-js/scala-js-dom.git",
@@ -83,4 +86,8 @@ lazy val readme = ScalatexReadme(
 lazy val example = project.
   enablePlugins(ScalaJSPlugin).
   settings(commonSettings: _*).
+  settings(
+    // Temporarily disregard @JSExport-on-object warnings of Scala.js 0.6.15
+    scalacOptions += "-P:scalajs:suppressExportDeprecations"
+  ).
   dependsOn(root)

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,10 +1,11 @@
 package example
 
+import scala.scalajs.js.annotation._
+
 import org.scalajs.dom
 import dom.html
-import scala.scalajs.js.annotation.JSExport
 
-@JSExport
+@JSExportTopLevel("example.Alert")
 object Alert {
   @JSExport
   def main() = {
@@ -13,7 +14,7 @@ object Alert {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.NodeAppendChild")
 object NodeAppendChild {
   @JSExport
   def main(div: html.Div) = {
@@ -27,7 +28,7 @@ object NodeAppendChild {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.ElementStyle")
 object ElementStyle {
   @JSExport
   def main(div: html.Div) = {
@@ -42,7 +43,7 @@ object ElementStyle {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.LocalStorage")
 object LocalStorage {
   @JSExport
   def main(in: html.Input, box: html.Div) = {
@@ -61,7 +62,7 @@ object LocalStorage {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.Canvas")
 object Canvas {
   @JSExport
   def main(c: html.Canvas) = {
@@ -87,7 +88,7 @@ object Canvas {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.Base64")
 object Base64 {
   @JSExport
   def main(in: html.Input,
@@ -99,7 +100,7 @@ object Base64 {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.EventHandler")
 object EventHandler{
   @JSExport
   def main(pre: html.Pre) = {
@@ -117,7 +118,7 @@ object EventHandler{
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.XMLHttpRequest")
 object XMLHttpRequest{
   @JSExport
   def main(pre: html.Pre) = {
@@ -136,7 +137,7 @@ object XMLHttpRequest{
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.Websocket")
 object Websocket {
   @JSExport
   def main(in: html.Input,
@@ -156,7 +157,7 @@ object Websocket {
   }
 }
 
-@JSExport
+@JSExportTopLevel("example.AjaxExtension")
 object AjaxExtension {
   @JSExport
   def main(pre: html.Pre) = {

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,5 +3,3 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.2.1")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.1")
-
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.3.2")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.2.1")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.3.2")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.2.1")
 

--- a/readme/Index.scalatex
+++ b/readme/Index.scalatex
@@ -23,12 +23,12 @@
     ),
     div(width:="50%", float.left, padding:="8px", boxSizing.`border-box`)(
       if (!autorun)
-        a(cls:="pure-button", onclick:=s"example.$example().main($queries)", "Run"),
+        a(cls:="pure-button", onclick:=s"example.$example.main($queries)", "Run"),
       div(
         frags.zip(ids).map{case (f, i) => f(id:=i, backgroundColor:="#fafafa")}
       ),
       if (autorun)
-        script(s"example.$example().main($queries)")
+        script(s"example.$example.main($queries)")
     ),
     div(clear.both)
   )

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -33,6 +33,7 @@ object Fetch extends js.Object {
  * @param init initialisation information
  */
 @js.native
+@JSGlobal
 class Request(input: RequestInfo, init: RequestInit = null) extends js.Object {
 
   /**
@@ -167,6 +168,7 @@ trait RequestInit extends js.Object {
  * @param init optional response initialisiton
  */
 @js.native
+@JSGlobal
 class Response(content: BodyInit = null, init: ResponseInit = null)
     extends Body {
 
@@ -202,6 +204,7 @@ class Response(content: BodyInit = null, init: ResponseInit = null)
  * whatwg Fetch spec.
  */
 @js.native
+@JSGlobal
 object Response extends js.Object {
 
   /**
@@ -310,6 +313,7 @@ trait Body extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Headers(map: HeadersInit = js.Array[js.Array[String]]())
     extends JSIterable[js.Array[ByteString]] {
 

--- a/src/main/scala/org/scalajs/dom/experimental/Notification.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Notification.scala
@@ -1,8 +1,9 @@
 package org.scalajs.dom.experimental
 
-import org.scalajs.dom.raw.EventTarget
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation._
+
+import org.scalajs.dom.raw.EventTarget
 
 @js.native
 trait NotificationOptions extends js.Object {
@@ -181,6 +182,7 @@ object NotificationOptions {
  * https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API
  */
 @js.native
+@JSGlobal
 object Notification extends js.Object {
 
   /**
@@ -215,7 +217,7 @@ object Notification extends js.Object {
  * @param options   The options to configure this notification
  * @return a new Notification
  */
-@JSName("Notification")
+@JSGlobal("Notification")
 @js.native
 class Notification(title: String, options: NotificationOptions = ???)
     extends EventTarget {

--- a/src/main/scala/org/scalajs/dom/experimental/Stream.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Stream.scala
@@ -1,6 +1,7 @@
 package org.scalajs.dom.experimental
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 // the stream API is defined in https://streams.spec.whatwg.org/
 
@@ -253,6 +254,7 @@ trait ReadableStream[+T] extends js.Object {
  * @tparam T Type of the Chunks returned by the Stream
  */
 @js.native
+@JSGlobal
 class ReadableStreamReader[+T](stream: ReadableStream[T]) extends js.Object {
 
   /**
@@ -321,6 +323,7 @@ class ReadableStreamReader[+T](stream: ReadableStream[T]) extends js.Object {
 
  */
 @js.native
+@JSGlobal
 class ReadableStreamController[-T](stream: ReadableStream[T] = null)
     extends js.Object {
 

--- a/src/main/scala/org/scalajs/dom/experimental/URL.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/URL.scala
@@ -1,6 +1,7 @@
 package org.scalajs.dom.experimental
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /**
  * The URL() constructor returns a newly created URL object representing the URL
@@ -9,6 +10,7 @@ import scala.scalajs.js
  * MDN
  */
 @js.native
+@JSGlobal
 class URL(url: String, base: String = js.native) extends js.Object {
 
   /**

--- a/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
@@ -3,9 +3,10 @@ package org.scalajs.dom.experimental.deviceorientation
 import org.scalajs.dom
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.ScalaJSDefined
+import scala.scalajs.js.annotation._
 
 @js.native
+@JSGlobal
 class DeviceOrientationEvent(
     `type`: String,
     eventInitDict: DeviceOrientationEventInit
@@ -84,6 +85,7 @@ trait DeviceRotationRate extends js.Any {
 }
 
 @js.native
+@JSGlobal
 class DeviceMotionEvent extends dom.Event {
 
   /** Device acceleration with gravity removed. */

--- a/src/main/scala/org/scalajs/dom/experimental/domparser/DOMParser.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/domparser/DOMParser.scala
@@ -1,6 +1,7 @@
 package org.scalajs.dom.experimental.domparser
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 import scala.scalajs.js.|
 
 import org.scalajs.dom.raw.{Document, HTMLDocument}
@@ -11,6 +12,7 @@ import org.scalajs.dom.raw.{Document, HTMLDocument}
  * MDN
  */
 @js.native
+@JSGlobal
 class DOMParser extends js.Object {
 
   /**

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -6,9 +6,10 @@
 
 package org.scalajs.dom.experimental.gamepad
 
-import org.scalajs.dom
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{ScalaJSDefined, JSName}
+import scala.scalajs.js.annotation._
+
+import org.scalajs.dom
 
 @js.native
 trait GamepadMappingType extends js.Any
@@ -76,7 +77,7 @@ object GamepadEventInit {
     js.Dynamic.literal("gamepad" -> gamepad).asInstanceOf[GamepadEventInit]
 }
 
-@JSName("GamepadEvent")
+@JSGlobal("GamepadEvent")
 @js.native
 class GamepadEvent(init: GamepadEventInit) extends dom.Event {
   val gamepad: Gamepad = js.native

--- a/src/main/scala/org/scalajs/dom/experimental/intl/Intl.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/intl/Intl.scala
@@ -8,7 +8,7 @@ package org.scalajs.dom.experimental.intl
 
 import scala.scalajs.js
 import scala.scalajs.js.|
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation._
 
 /**
  * The Intl.Collator object is a constructor for collators, objects that enable language
@@ -17,7 +17,7 @@ import scala.scalajs.js.annotation.JSName
  * MDN
  */
 @js.native
-@JSName("Intl.Collator")
+@JSGlobal("Intl.Collator")
 class Collator(locales: js.UndefOr[String | js.Array[String]] = js.undefined,
     options: js.UndefOr[CollatorOptions] = js.undefined)
     extends js.Object {
@@ -34,7 +34,7 @@ class Collator(locales: js.UndefOr[String | js.Array[String]] = js.undefined,
  * MDN
  */
 @js.native
-@JSName("Intl.DateTimeFormat")
+@JSGlobal("Intl.DateTimeFormat")
 class DateTimeFormat(locales: String | js.Array[String],
     options: js.UndefOr[DateTimeFormatOptions] = js.undefined)
     extends js.Object {
@@ -51,7 +51,7 @@ class DateTimeFormat(locales: String | js.Array[String],
  * MDN
  */
 @js.native
-@JSName("Intl.NumberFormat")
+@JSGlobal("Intl.NumberFormat")
 class NumberFormat(locales: String | js.Array[String],
     options: js.UndefOr[NumberFormatOptions])
     extends js.Object {

--- a/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
@@ -4,8 +4,10 @@
 package org.scalajs.dom.experimental.mediastream
 
 import scala.scalajs.js
-import org.scalajs.dom.raw.{DOMError, Event, EventTarget}
 import scala.scalajs.js.|
+import scala.scalajs.js.annotation._
+
+import org.scalajs.dom.raw.{DOMError, Event, EventTarget}
 
 /**
  * The MediaStream
@@ -16,6 +18,7 @@ import scala.scalajs.js.|
  *
  */
 @js.native
+@JSGlobal
 class MediaStream() extends EventTarget {
 
   /**
@@ -479,6 +482,7 @@ object MediaStreamTrackEventInit {
 }
 
 @js.native
+@JSGlobal
 class MediaStreamTrackEvent(`type`: String,
     eventInitDict: MediaStreamTrackEventInit)
     extends Event {

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -85,6 +85,7 @@ trait CanvasProxy extends js.Any {
  * on whatwg ServiceWorker spec.
  */
 @js.native
+@JSGlobal
 class FetchEvent extends Event {
 
   /**
@@ -351,6 +352,7 @@ trait ServiceWorkerContainer extends EventTarget {
  * array of promises). It is initially set to null.
  */
 @js.native
+@JSGlobal
 class ExtendableEvent extends Event {
   def waitUntil(promise: js.Promise[Any]): Unit = js.native
 }
@@ -375,6 +377,7 @@ trait ExtendableMessageEventInit extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class ExtendableMessageEvent(`type`: String,
     eventInitDict: ExtendableMessageEventInit)
     extends ExtendableEvent {
@@ -429,6 +432,7 @@ trait ServiceWorkerMessageEventInit extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class ServiceWorkerMessageEvent(`type`: String,
     eventInitDict: ServiceWorkerMessageEventInit = js.native)
     extends Event {
@@ -597,6 +601,7 @@ trait Clients extends js.Object {
  * of ServiceWorker whatwg spec.
  */
 @js.native
+@JSGlobal
 abstract class Cache extends js.Object {
   def `match`(request: RequestInfo,
       options: js.UndefOr[

--- a/src/main/scala/org/scalajs/dom/experimental/sharedworkers/SharedWorker.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/sharedworkers/SharedWorker.scala
@@ -1,9 +1,10 @@
 package org.scalajs.dom.experimental.sharedworkers
 
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
 import org.scalajs.dom.raw.MessagePort
 import org.scalajs.dom.webworkers
-
-import scala.scalajs.js
 
 /**
  * The SharedWorker interface represents a specific kind of worker that can be
@@ -28,6 +29,7 @@ import scala.scalajs.js
  *             shared worker.
  */
 @js.native
+@JSGlobal
 class SharedWorker(stringUrl: String, name: js.UndefOr[String] = js.native)
     extends webworkers.AbstractWorker {
 

--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
@@ -3,12 +3,14 @@
  */
 package org.scalajs.dom.experimental.webrtc
 
-import org.scalajs.dom.Blob
-import org.scalajs.dom.raw.{DOMError, Event, EventTarget, MessageEvent}
 import scala.scalajs.js
-import org.scalajs.dom.experimental.mediastream._
+import scala.scalajs.js.annotation._
 import scala.scalajs.js.typedarray.{ArrayBufferView, ArrayBuffer}
 import scala.scalajs.js.|
+
+import org.scalajs.dom.Blob
+import org.scalajs.dom.raw.{DOMError, Event, EventTarget, MessageEvent}
+import org.scalajs.dom.experimental.mediastream._
 
 @js.native
 trait RTCIdentityAssertion extends js.Object {
@@ -260,6 +262,7 @@ object RTCSessionDescriptionInit {
 }
 
 @js.native
+@JSGlobal
 class RTCSessionDescription(
     descriptionInitDict: js.UndefOr[RTCSessionDescriptionInit] = js.undefined)
     extends js.Object {
@@ -309,6 +312,7 @@ object RTCIceCandidateInit {
  * MDN
  */
 @js.native
+@JSGlobal
 class RTCIceCandidate(candidateInitDict: RTCIceCandidateInit)
     extends js.Object {
 
@@ -493,6 +497,7 @@ trait RTCDataChannelInit extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class RTCDataChannelEvent protected () extends Event {
   def this(eventInitDict: RTCDataChannelEventInit) = this()
 
@@ -653,6 +658,7 @@ object RTCPeerConnectionIceEventInit {
  * MDN
  */
 @js.native
+@JSGlobal
 class RTCPeerConnectionIceEvent(`type`: String,
     eventInitDict: RTCPeerConnectionIceEventInit)
     extends Event {
@@ -777,6 +783,7 @@ object RTCIceGatheringState {
  * MDN
  */
 @js.native
+@JSGlobal
 class MediaStreamEvent(`type`: String, ms: js.Dictionary[js.Any])
     extends Event {
   val stream: MediaStream = js.native
@@ -790,6 +797,7 @@ class MediaStreamEvent(`type`: String, ms: js.Dictionary[js.Any])
  * MDN
  */
 @js.native
+@JSGlobal
 class RTCPeerConnection(
     configuration: js.UndefOr[RTCConfiguration] = js.undefined)
     extends EventTarget {

--- a/src/main/scala/org/scalajs/dom/raw/Audio.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Audio.scala
@@ -12,6 +12,7 @@ package org.scalajs.dom.raw
 import org.scalajs.dom.experimental.mediastream.MediaStream
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** The AudioContext interface represents an audio-processing graph built
  *  from audio modules linked together, each represented by an AudioNode.
@@ -24,6 +25,7 @@ import scala.scalajs.js
  *  EventTarget interface.
  */
 @js.native
+@JSGlobal
 class AudioContext extends EventTarget {
 
   /** Returns a double representing an ever-increasing hardware time in
@@ -247,6 +249,7 @@ class AudioContext extends EventTarget {
  *                       most commonly used.
  */
 @js.native
+@JSGlobal
 class OfflineAudioContext(numOfChannels: Int, length: Int, sampleRate: Int)
     extends AudioContext {
 

--- a/src/main/scala/org/scalajs/dom/raw/Css.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Css.scala
@@ -10,6 +10,7 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /**
  * A CSSStyleDeclaration is an interface to the declaration block returned by the
@@ -18,6 +19,7 @@ import scala.scalajs.js
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSStyleDeclaration extends js.Object {
   var backgroundAttachment: String = js.native
   var visibility: String = js.native
@@ -236,6 +238,7 @@ class CSSStyleDeclaration extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSStyleSheet extends StyleSheet {
   var owningElement: Element = js.native
   var imports: StyleSheetList = js.native
@@ -295,6 +298,7 @@ class CSSStyleSheet extends StyleSheet {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSStyleRule extends CSSRule {
 
   /**
@@ -314,6 +318,7 @@ class CSSStyleRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSMediaRule extends CSSRule {
 
   /**
@@ -338,6 +343,7 @@ class CSSMediaRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSNamespaceRule extends CSSRule {
 
   /**
@@ -357,6 +363,7 @@ class CSSNamespaceRule extends CSSRule {
 }
 
 @js.native
+@JSGlobal
 class CSSImportRule extends CSSRule {
   var styleSheet: CSSStyleSheet = js.native
   var href: String = js.native
@@ -371,6 +378,7 @@ class CSSImportRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSRule extends js.Object {
 
   /**
@@ -411,6 +419,7 @@ class CSSRule extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object CSSRule extends js.Object {
   var IMPORT_RULE: Int = js.native
   var MEDIA_RULE: Int = js.native
@@ -423,6 +432,7 @@ object CSSRule extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class CSSFontFaceRule extends CSSRule {
   var style: CSSStyleDeclaration = js.native
 }
@@ -434,6 +444,7 @@ class CSSFontFaceRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSPageRule extends CSSRule {
   var pseudoClass: String = js.native
 
@@ -460,6 +471,7 @@ class CSSPageRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSRuleList extends DOMList[CSSRule]
 
 /**
@@ -471,6 +483,7 @@ class CSSRuleList extends DOMList[CSSRule]
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSKeyframesRule extends CSSRule {
 
   /**
@@ -525,6 +538,7 @@ class CSSKeyframesRule extends CSSRule {
  * MDN
  */
 @js.native
+@JSGlobal
 class CSSKeyframeRule extends CSSRule {
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -10,8 +10,10 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 @js.native
+@JSGlobal
 abstract class HTMLDocument extends Document {
 
   /**
@@ -555,6 +557,7 @@ abstract class HTMLDocument extends Document {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableElement extends HTMLElement {
 
   /**
@@ -776,6 +779,7 @@ abstract class HTMLTableElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableDataCellElement extends HTMLTableCellElement
 
 /**
@@ -786,6 +790,7 @@ abstract class HTMLTableDataCellElement extends HTMLTableCellElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLBaseElement extends HTMLElement {
 
   /**
@@ -820,6 +825,7 @@ trait HTMLNextIdElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLParagraphElement extends HTMLElement {
 
   /**
@@ -841,6 +847,7 @@ trait HTMLAreasCollection extends HTMLCollection {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 5")
 abstract class HTMLAppletElement extends HTMLElement {
   var width: Double = js.native
@@ -872,6 +879,7 @@ abstract class HTMLAppletElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLOListElement extends HTMLElement {
 
   /**
@@ -891,6 +899,7 @@ abstract class HTMLOListElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLSelectElement extends HTMLElement {
 
   /**
@@ -1052,6 +1061,7 @@ trait HTMLBlockElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLMetaElement extends HTMLElement {
 
   /**
@@ -1087,6 +1097,7 @@ abstract class HTMLMetaElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 abstract class HTMLDDElement extends HTMLElement {
   var noWrap: Boolean = js.native
 }
@@ -1100,6 +1111,7 @@ abstract class HTMLDDElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLLinkElement extends HTMLElement with LinkStyle {
 
   /**
@@ -1157,6 +1169,7 @@ abstract class HTMLLinkElement extends HTMLElement with LinkStyle {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 4.01")
 abstract class HTMLFontElement extends HTMLElement {
   var face: String = js.native
@@ -1170,6 +1183,7 @@ abstract class HTMLFontElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableCaptionElement extends HTMLElement {
 
   /**
@@ -1192,6 +1206,7 @@ abstract class HTMLTableCaptionElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLOptionElement extends HTMLElement {
 
   /**
@@ -1271,6 +1286,7 @@ abstract class HTMLOptionElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLMapElement extends HTMLElement {
 
   /**
@@ -1291,6 +1307,7 @@ abstract class HTMLMapElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 abstract class HTMLMenuElement extends HTMLElement {
   var `type`: String = js.native
 }
@@ -1302,6 +1319,7 @@ abstract class HTMLMenuElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLCollection extends DOMList[Element] {
 
   /**
@@ -1333,6 +1351,7 @@ abstract class HTMLCollection extends DOMList[Element] {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLImageElement extends HTMLElement {
 
   /**
@@ -1455,6 +1474,7 @@ abstract class HTMLImageElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLAreaElement extends HTMLElement {
 
   /**
@@ -1567,6 +1587,7 @@ abstract class HTMLAreaElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLButtonElement extends HTMLElement {
 
   /**
@@ -1687,6 +1708,7 @@ abstract class HTMLButtonElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLSourceElement extends HTMLElement {
 
   /**
@@ -1715,6 +1737,7 @@ abstract class HTMLSourceElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLScriptElement extends HTMLElement {
   var defer: Boolean = js.native
 
@@ -1786,6 +1809,7 @@ abstract class HTMLScriptElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableRowElement
     extends HTMLElement with HTMLTableAlignment {
 
@@ -1855,6 +1879,7 @@ abstract class HTMLTableRowElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLHtmlElement extends HTMLElement {
 
   /**
@@ -1868,6 +1893,7 @@ abstract class HTMLHtmlElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 5")
 abstract class HTMLFrameElement extends HTMLElement with GetSVGDocument {
   var width: js.Any = js.native
@@ -1898,6 +1924,7 @@ abstract class HTMLFrameElement extends HTMLElement with GetSVGDocument {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLQuoteElement extends HTMLElement {
   var dateTime: String = js.native
 
@@ -1918,6 +1945,7 @@ abstract class HTMLQuoteElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableHeaderCellElement extends HTMLTableCellElement
 
 /**
@@ -1928,9 +1956,11 @@ abstract class HTMLTableHeaderCellElement extends HTMLTableCellElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLDListElement extends HTMLElement
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 5")
 abstract class HTMLFrameSetElement extends HTMLElement {
   var ononline: js.Function1[Event, _] = js.native
@@ -1961,6 +1991,7 @@ abstract class HTMLFrameSetElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLLabelElement extends HTMLElement {
 
   /**
@@ -1981,6 +2012,7 @@ abstract class HTMLLabelElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLLegendElement extends HTMLElement {
   var align: String = js.native
 
@@ -1988,6 +2020,7 @@ abstract class HTMLLegendElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 4")
 abstract class HTMLDirectoryElement extends HTMLElement
 
@@ -1999,6 +2032,7 @@ abstract class HTMLDirectoryElement extends HTMLElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLLIElement extends HTMLElement {
 
   /**
@@ -2020,6 +2054,7 @@ abstract class HTMLLIElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLIFrameElement extends HTMLElement with GetSVGDocument {
 
   /**
@@ -2093,6 +2128,7 @@ abstract class HTMLIFrameElement extends HTMLElement with GetSVGDocument {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLBodyElement extends HTMLElement {
   var scroll: String = js.native
 
@@ -2231,6 +2267,7 @@ abstract class HTMLBodyElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableSectionElement
     extends HTMLElement with HTMLTableAlignment {
 
@@ -2276,6 +2313,7 @@ abstract class HTMLTableSectionElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLInputElement extends HTMLElement {
 
   /**
@@ -2678,6 +2716,7 @@ abstract class HTMLInputElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLAnchorElement extends HTMLElement {
 
   /**
@@ -2824,6 +2863,7 @@ abstract class HTMLAnchorElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLParamElement extends HTMLElement {
 
   /**
@@ -2869,6 +2909,7 @@ abstract class HTMLParamElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLPreElement extends HTMLElement {
 
   /**
@@ -2882,6 +2923,7 @@ abstract class HTMLPreElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 abstract class HTMLPhraseElement extends HTMLElement {
   var dateTime: String = js.native
 }
@@ -2895,6 +2937,7 @@ abstract class HTMLPhraseElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLCanvasElement extends HTMLElement {
 
   /**
@@ -2947,6 +2990,7 @@ abstract class HTMLCanvasElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTitleElement extends HTMLElement {
 
   /**
@@ -2964,6 +3008,7 @@ abstract class HTMLTitleElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLStyleElement extends HTMLElement with LinkStyle {
 
   /**
@@ -2990,6 +3035,7 @@ abstract class HTMLStyleElement extends HTMLElement with LinkStyle {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLUnknownElement extends HTMLElement
 
 /**
@@ -3000,6 +3046,7 @@ abstract class HTMLUnknownElement extends HTMLElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLAudioElement extends HTMLMediaElement
 
 /**
@@ -3011,6 +3058,7 @@ abstract class HTMLAudioElement extends HTMLMediaElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableCellElement
     extends HTMLElement with HTMLTableAlignment {
 
@@ -3101,6 +3149,7 @@ abstract class HTMLTableCellElement
  * MDN
  */
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "DOM Level 2")
 abstract class HTMLBaseFontElement extends HTMLElement {
 
@@ -3133,6 +3182,7 @@ abstract class HTMLBaseFontElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTextAreaElement extends HTMLElement {
 
   /**
@@ -3333,6 +3383,7 @@ abstract class HTMLTextAreaElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLModElement extends HTMLElement {
   var dateTime: String = js.native
 
@@ -3353,6 +3404,7 @@ abstract class HTMLModElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTableColElement
     extends HTMLElement with HTMLTableAlignment {
 
@@ -3394,6 +3446,7 @@ trait HTMLTableAlignment extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLUListElement extends HTMLElement
 
 /**
@@ -3404,6 +3457,7 @@ abstract class HTMLUListElement extends HTMLElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLDivElement extends HTMLElement {
 
   /**
@@ -3424,6 +3478,7 @@ abstract class HTMLDivElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLBRElement extends HTMLElement {
 
   /**
@@ -3443,6 +3498,7 @@ abstract class HTMLBRElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLMediaElement extends HTMLElement {
 
   /**
@@ -3660,6 +3716,7 @@ abstract class HTMLMediaElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 object HTMLMediaElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(HTMLMediaElement),List())))) */
   /**
@@ -3714,6 +3771,7 @@ object HTMLMediaElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class HTMLDTElement extends HTMLElement {
   var noWrap: Boolean = js.native
 }
@@ -3726,6 +3784,7 @@ abstract class HTMLDTElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLFieldSetElement extends HTMLElement {
 
   @deprecated("Obsolete.", "HTML 5")
@@ -3792,6 +3851,7 @@ abstract class HTMLFieldSetElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Non standard.", "forever")
 abstract class HTMLBGSoundElement extends HTMLElement {
   var balance: js.Any = js.native
@@ -3807,6 +3867,7 @@ abstract class HTMLBGSoundElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLElement extends Element {
   var onblur: js.Function1[FocusEvent, _] = js.native
   var onfocus: js.Function1[FocusEvent, _] = js.native
@@ -4066,6 +4127,7 @@ abstract class HTMLElement extends Element {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLHRElement extends HTMLElement {
   @deprecated("Obsolete.", "HTML 5")
   var width: Double = js.native
@@ -4089,6 +4151,7 @@ abstract class HTMLHRElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
 
   /**
@@ -4254,6 +4317,7 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLEmbedElement extends HTMLElement with GetSVGDocument {
 
   /**
@@ -4289,6 +4353,7 @@ abstract class HTMLEmbedElement extends HTMLElement with GetSVGDocument {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLOptGroupElement extends HTMLElement {
 
   /**
@@ -4314,6 +4379,7 @@ abstract class HTMLOptGroupElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 4.01")
 abstract class HTMLIsIndexElement extends HTMLElement {
 
@@ -4342,6 +4408,7 @@ abstract class HTMLIsIndexElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLVideoElement extends HTMLMediaElement {
 
   /**
@@ -4398,6 +4465,7 @@ abstract class HTMLVideoElement extends HTMLMediaElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLProgressElement extends HTMLElement {
 
   /**
@@ -4435,6 +4503,7 @@ abstract class HTMLProgressElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLDataListElement extends HTMLElement {
 
   /**
@@ -4452,6 +4521,7 @@ abstract class HTMLDataListElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLTrackElement extends HTMLElement {
   var kind: String = js.native
   var src: String = js.native
@@ -4461,6 +4531,7 @@ abstract class HTMLTrackElement extends HTMLElement {
 }
 
 @js.native
+@JSGlobal
 @deprecated("Obsolete.", "HTML 5")
 abstract class HTMLMarqueeElement extends HTMLElement {
   var width: String = js.native
@@ -4490,6 +4561,7 @@ abstract class HTMLMarqueeElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLSpanElement extends HTMLElement
 
 /**
@@ -4500,6 +4572,7 @@ abstract class HTMLSpanElement extends HTMLElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLHeadElement extends HTMLElement {
 
   /**
@@ -4518,6 +4591,7 @@ abstract class HTMLHeadElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLHeadingElement extends HTMLElement {
 
   /**
@@ -4537,6 +4611,7 @@ abstract class HTMLHeadingElement extends HTMLElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class HTMLFormElement extends HTMLElement {
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -10,6 +10,7 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /**
  * The IDBObjectStore interface of the IndexedDB API represents an object store in
@@ -19,6 +20,7 @@ import scala.scalajs.js
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBObjectStore extends js.Object {
 
   /**
@@ -127,6 +129,7 @@ class IDBObjectStore extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBVersionChangeEvent extends Event {
 
   /**
@@ -167,6 +170,7 @@ class IDBVersionChangeEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBIndex extends js.Object {
 
   /**
@@ -250,6 +254,7 @@ class IDBIndex extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBCursor extends js.Object {
 
   /**
@@ -322,6 +327,7 @@ class IDBCursor extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object IDBCursor extends js.Object {
 
   val PREV: String = js.native
@@ -336,6 +342,7 @@ object IDBCursor extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBCursorWithValue extends IDBCursor {
   def value: js.Any = js.native
 }
@@ -375,6 +382,7 @@ trait IDBEnvironment extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBKeyRange extends js.Object {
 
   /**
@@ -407,6 +415,7 @@ class IDBKeyRange extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object IDBKeyRange extends js.Object {
 
   /**
@@ -454,6 +463,7 @@ object IDBKeyRange extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBTransaction extends EventTarget {
 
   /**
@@ -524,6 +534,7 @@ class IDBTransaction extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object IDBTransaction extends js.Object {
 
   /**
@@ -566,6 +577,7 @@ object IDBTransaction extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBDatabase extends EventTarget {
 
   /**
@@ -656,6 +668,7 @@ class IDBDatabase extends EventTarget {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBOpenDBRequest extends IDBRequest {
 
   /**
@@ -688,6 +701,7 @@ class IDBOpenDBRequest extends IDBRequest {
  *
  */
 @js.native
+@JSGlobal
 class IDBFactory extends js.Object {
   def open(name: String, version: Int): IDBOpenDBRequest = js.native
 
@@ -730,6 +744,7 @@ class IDBFactory extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class IDBRequest extends EventTarget {
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -10,6 +10,7 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 @js.native
 trait GetSVGDocument extends js.Object {
@@ -17,6 +18,7 @@ trait GetSVGDocument extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoQuadraticRel extends SVGPathSeg {
   var y: Double = js.native
   var y1: Double = js.native
@@ -32,6 +34,7 @@ class SVGPathSegCurvetoQuadraticRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGMarkerElement
     extends SVGElement with SVGStylable with SVGLangSpace with SVGFitToViewBox
     with SVGExternalResourcesRequired {
@@ -54,6 +57,7 @@ abstract class SVGMarkerElement
 }
 
 @js.native
+@JSGlobal
 object SVGMarkerElement extends js.Object {
   val SVG_MARKER_ORIENT_UNKNOWN: Int = js.native
   val SVG_MARKER_ORIENT_ANGLE: Int = js.native
@@ -69,11 +73,13 @@ object SVGMarkerElement extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGGElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoCubicSmoothAbs extends SVGPathSeg {
   var y: Double = js.native
   var x2: Double = js.native
@@ -82,6 +88,7 @@ class SVGPathSegCurvetoCubicSmoothAbs extends SVGPathSeg {
 }
 
 @js.native
+@JSGlobal
 class SVGZoomEvent extends UIEvent {
   def zoomRectScreen: SVGRect = js.native
 
@@ -102,6 +109,7 @@ trait SVGUnitTypes extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object SVGUnitTypes extends js.Object {
   val SVG_UNIT_TYPE_UNKNOWN: Int = js.native
   val SVG_UNIT_TYPE_OBJECTBOUNDINGBOX: Int = js.native
@@ -109,6 +117,7 @@ object SVGUnitTypes extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegMovetoRel extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
@@ -121,6 +130,7 @@ class SVGPathSegMovetoRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGLineElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired {
@@ -160,10 +170,12 @@ abstract class SVGLineElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGDescElement
     extends SVGElement with SVGStylable with SVGLangSpace
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoQuadraticSmoothRel extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
@@ -176,6 +188,7 @@ class SVGPathSegCurvetoQuadraticSmoothRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGClipPathElement
     extends SVGElement with SVGUnitTypes with SVGStylable with SVGTransformable
     with SVGLangSpace with SVGTests with SVGExternalResourcesRequired {
@@ -197,6 +210,7 @@ abstract class SVGClipPathElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGTextPositioningElement extends SVGTextContentElement {
 
   /**
@@ -236,6 +250,7 @@ abstract class SVGTextPositioningElement extends SVGTextContentElement {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoVerticalRel extends SVGPathSeg {
   var y: Double = js.native
 }
@@ -247,6 +262,7 @@ class SVGPathSegLinetoVerticalRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedString extends js.Object {
 
   /**
@@ -310,6 +326,7 @@ trait SVGTests extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGPatternElement
     extends SVGElement with SVGUnitTypes with SVGStylable with SVGLangSpace
     with SVGTests with SVGFitToViewBox with SVGExternalResourcesRequired
@@ -374,6 +391,7 @@ abstract class SVGPatternElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedAngle extends js.Object {
 
   /**
@@ -401,6 +419,7 @@ class SVGAnimatedAngle extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGScriptElement
     extends SVGElement with SVGExternalResourcesRequired with SVGURIReference {
   def `type`: String = js.native
@@ -413,6 +432,7 @@ abstract class SVGScriptElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGViewElement
     extends SVGElement with SVGZoomAndPan with SVGFitToViewBox
     with SVGExternalResourcesRequired {
@@ -448,6 +468,7 @@ trait SVGLocatable extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGTitleElement
     extends SVGElement with SVGStylable with SVGLangSpace
 
@@ -458,6 +479,7 @@ abstract class SVGTitleElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedTransformList extends js.Object {
 
   /**
@@ -486,6 +508,7 @@ trait SVGFitToViewBox extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPointList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -511,6 +534,7 @@ class SVGPointList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedLengthList extends js.Object {
 
   /**
@@ -539,6 +563,7 @@ class SVGAnimatedLengthList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedPreserveAspectRatio extends js.Object {
 
   /**
@@ -571,6 +596,7 @@ trait SVGExternalResourcesRequired extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAngle extends js.Object {
 
   /**
@@ -646,6 +672,7 @@ class SVGAngle extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 object SVGAngle extends js.Object {
 
   val SVG_ANGLETYPE_RAD: Int = js.native
@@ -675,6 +702,7 @@ object SVGAngle extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGElement extends Element {
   var onmouseover: js.Function1[MouseEvent, _] = js.native
 
@@ -713,11 +741,13 @@ abstract class SVGElement extends Element {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoHorizontalAbs extends SVGPathSeg {
   var x: Double = js.native
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegArcAbs extends SVGPathSeg {
   var y: Double = js.native
   var sweepFlag: Boolean = js.native
@@ -734,6 +764,7 @@ class SVGPathSegArcAbs extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGTransformList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -829,6 +860,7 @@ class SVGTransformList extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegClosePath extends SVGPathSeg
 
 /**
@@ -838,6 +870,7 @@ class SVGPathSegClosePath extends SVGPathSeg
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedLength extends js.Object {
 
   /**
@@ -891,11 +924,13 @@ trait SVGAnimatedPoints extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGDefsElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoHorizontalRel extends SVGPathSeg {
   var x: Double = js.native
 }
@@ -907,6 +942,7 @@ class SVGPathSegLinetoHorizontalRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGEllipseElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired {
@@ -947,6 +983,7 @@ abstract class SVGEllipseElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGAElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired with SVGURIReference {
@@ -1008,6 +1045,7 @@ trait SVGLangSpace extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPoint extends js.Object {
   var y: Double = js.native
   var x: Double = js.native
@@ -1022,6 +1060,7 @@ class SVGPoint extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedNumberList extends js.Object {
 
   /**
@@ -1052,6 +1091,7 @@ class SVGAnimatedNumberList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGSVGElement
     extends SVGElement with SVGStylable with SVGZoomAndPan with DocumentEvent
     with SVGLangSpace with SVGLocatable with SVGTests with SVGFitToViewBox
@@ -1394,6 +1434,7 @@ abstract class SVGSVGElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedInteger extends js.Object {
 
   /**
@@ -1419,6 +1460,7 @@ class SVGAnimatedInteger extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGTextElement
     extends SVGTextPositioningElement with SVGTransformable
 
@@ -1429,9 +1471,11 @@ abstract class SVGTextElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGTSpanElement extends SVGTextPositioningElement
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoVerticalAbs extends SVGPathSeg {
   var y: Double = js.native
 }
@@ -1442,6 +1486,7 @@ class SVGPathSegLinetoVerticalAbs extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGStyleElement extends SVGElement with SVGLangSpace {
 
   /**
@@ -1472,6 +1517,7 @@ abstract class SVGStyleElement extends SVGElement with SVGLangSpace {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGRadialGradientElement extends SVGGradientElement {
 
   /**
@@ -1516,6 +1562,7 @@ class SVGRadialGradientElement extends SVGGradientElement {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGImageElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired with SVGURIReference {
@@ -1563,6 +1610,7 @@ abstract class SVGImageElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedNumber extends js.Object {
 
   /**
@@ -1583,9 +1631,11 @@ class SVGAnimatedNumber extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGMetadataElement extends SVGElement
 
 @js.native
+@JSGlobal
 class SVGPathSegArcRel extends SVGPathSeg {
   var y: Double = js.native
   var sweepFlag: Boolean = js.native
@@ -1597,6 +1647,7 @@ class SVGPathSegArcRel extends SVGPathSeg {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegMovetoAbs extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
@@ -1608,6 +1659,7 @@ class SVGPathSegMovetoAbs extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGStringList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -1703,6 +1755,7 @@ class SVGStringList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGLength extends js.Object {
 
   /**
@@ -1781,6 +1834,7 @@ class SVGLength extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 object SVGLength extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGLength),List())))) */
   val SVG_LENGTHTYPE_NUMBER: Int = js.native
@@ -1810,11 +1864,13 @@ object SVGLength extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGPolygonElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGAnimatedPoints with SVGTests with SVGExternalResourcesRequired
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoCubicRel extends SVGPathSeg {
   var y: Double = js.native
   var y1: Double = js.native
@@ -1825,6 +1881,7 @@ class SVGPathSegCurvetoCubicRel extends SVGPathSeg {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGTextContentElement
     extends SVGElement with SVGStylable with SVGLangSpace with SVGTests
     with SVGExternalResourcesRequired {
@@ -1852,6 +1909,7 @@ abstract class SVGTextContentElement
 }
 
 @js.native
+@JSGlobal
 object SVGTextContentElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGTextContentElement),List())))) */
   val LENGTHADJUST_SPACING: Int = js.native
@@ -1867,6 +1925,7 @@ object SVGTextContentElement extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGTransform extends js.Object {
   def `type`: Int = js.native
 
@@ -1970,6 +2029,7 @@ class SVGTransform extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 object SVGTransform extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGTransform),List())))) */
   val SVG_TRANSFORM_SKEWX: Int = js.native
@@ -1994,6 +2054,7 @@ trait SVGURIReference extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSeg extends js.Object {
   def pathSegType: Int = js.native
 
@@ -2001,6 +2062,7 @@ class SVGPathSeg extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object SVGPathSeg extends js.Object {
 
   val PATHSEG_MOVETO_REL: Int = js.native
@@ -2031,6 +2093,7 @@ object SVGPathSeg extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGNumber extends js.Object {
 
   /**
@@ -2049,6 +2112,7 @@ class SVGNumber extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGPathElement
     extends SVGElement with SVGStylable with SVGAnimatedPathData
     with SVGTransformable with SVGLangSpace with SVGTests
@@ -2295,6 +2359,7 @@ abstract class SVGPathElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedRect extends js.Object {
 
   /**
@@ -2317,6 +2382,7 @@ class SVGAnimatedRect extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -2336,6 +2402,7 @@ class SVGPathSegList extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGElementInstance extends EventTarget {
   def previousSibling: SVGElementInstance = js.native
 
@@ -2361,6 +2428,7 @@ class SVGElementInstance extends EventTarget {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGCircleElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired {
@@ -2395,6 +2463,7 @@ abstract class SVGCircleElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGRect extends js.Object {
 
   /**
@@ -2427,6 +2496,7 @@ class SVGRect extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoCubicAbs extends SVGPathSeg {
   var y: Double = js.native
   var y1: Double = js.native
@@ -2437,6 +2507,7 @@ class SVGPathSegCurvetoCubicAbs extends SVGPathSeg {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoQuadraticAbs extends SVGPathSeg {
   var y: Double = js.native
   var y1: Double = js.native
@@ -2445,6 +2516,7 @@ class SVGPathSegCurvetoQuadraticAbs extends SVGPathSeg {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoAbs extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
@@ -2456,6 +2528,7 @@ class SVGPathSegLinetoAbs extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGMatrix extends js.Object {
   var e: Double = js.native
   var c: Double = js.native
@@ -2564,6 +2637,7 @@ class SVGMatrix extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGUseElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired with SVGURIReference {
@@ -2625,6 +2699,7 @@ trait SVGException extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object SVGException extends js.Object {
   val SVG_MATRIX_NOT_INVERTABLE: Int = js.native
   val SVG_WRONG_TYPE_ERR: Int = js.native
@@ -2638,6 +2713,7 @@ object SVGException extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGLinearGradientElement extends SVGGradientElement {
 
   /**
@@ -2676,6 +2752,7 @@ class SVGLinearGradientElement extends SVGGradientElement {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedEnumeration extends js.Object {
 
   /**
@@ -2702,6 +2779,7 @@ class SVGAnimatedEnumeration extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGRectElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired {
@@ -2750,12 +2828,14 @@ abstract class SVGRectElement
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoQuadraticSmoothAbs extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegCurvetoCubicSmoothRel extends SVGPathSeg {
   var y: Double = js.native
   var x2: Double = js.native
@@ -2769,6 +2849,7 @@ class SVGPathSegCurvetoCubicSmoothRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGLengthList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -2865,6 +2946,7 @@ class SVGLengthList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGPolylineElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGAnimatedPoints with SVGTests with SVGExternalResourcesRequired
@@ -2880,6 +2962,7 @@ trait SVGZoomAndPan extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object SVGZoomAndPan extends js.Object {
   val SVG_ZOOMANDPAN_MAGNIFY: Int = js.native
   val SVG_ZOOMANDPAN_UNKNOWN: Int = js.native
@@ -2887,6 +2970,7 @@ object SVGZoomAndPan extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGTextPathElement
     extends SVGTextContentElement with SVGURIReference {
   def startOffset: SVGAnimatedLength = js.native
@@ -2897,6 +2981,7 @@ abstract class SVGTextPathElement
 }
 
 @js.native
+@JSGlobal
 object SVGTextPathElement extends js.Object {
 
   val TEXTPATH_SPACINGTYPE_EXACT: Int = js.native
@@ -2914,6 +2999,7 @@ object SVGTextPathElement extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGGradientElement
     extends SVGElement with SVGUnitTypes with SVGStylable
     with SVGExternalResourcesRequired with SVGURIReference {
@@ -2949,6 +3035,7 @@ abstract class SVGGradientElement
  * MDN
  */
 @js.native
+@JSGlobal
 object SVGGradientElement extends js.Object {
   val SVG_SPREADMETHOD_REFLECT: Int = js.native
   val SVG_SPREADMETHOD_PAD: Int = js.native
@@ -2969,6 +3056,7 @@ object SVGGradientElement extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGNumberList extends js.Object {
   def numberOfItems: Int = js.native
 
@@ -3059,6 +3147,7 @@ class SVGNumberList extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class SVGPathSegLinetoRel extends SVGPathSeg {
   var y: Double = js.native
   var x: Double = js.native
@@ -3071,6 +3160,7 @@ class SVGPathSegLinetoRel extends SVGPathSeg {
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGAnimatedBoolean extends js.Object {
 
   /**
@@ -3096,6 +3186,7 @@ class SVGAnimatedBoolean extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGSwitchElement
     extends SVGElement with SVGStylable with SVGTransformable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired
@@ -3107,6 +3198,7 @@ abstract class SVGSwitchElement
  * MDN
  */
 @js.native
+@JSGlobal
 class SVGPreserveAspectRatio extends js.Object {
 
   /**
@@ -3133,6 +3225,7 @@ class SVGPreserveAspectRatio extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 object SVGPreserveAspectRatio extends js.Object {
 
   val SVG_PRESERVEASPECTRATIO_NONE: Int = js.native
@@ -3176,6 +3269,7 @@ object SVGPreserveAspectRatio extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGStopElement extends SVGElement with SVGStylable {
 
   /**
@@ -3192,11 +3286,13 @@ abstract class SVGStopElement extends SVGElement with SVGStylable {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGSymbolElement
     extends SVGElement with SVGStylable with SVGLangSpace with SVGFitToViewBox
     with SVGExternalResourcesRequired
 
 @js.native
+@JSGlobal
 class SVGElementInstanceList extends js.Object {
   def length: Int = js.native
 
@@ -3210,6 +3306,7 @@ class SVGElementInstanceList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGMaskElement
     extends SVGElement with SVGUnitTypes with SVGStylable with SVGLangSpace
     with SVGTests with SVGExternalResourcesRequired {
@@ -3266,6 +3363,7 @@ abstract class SVGMaskElement
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class SVGFilterElement
     extends SVGElement with SVGUnitTypes with SVGStylable with SVGLangSpace
     with SVGURIReference with SVGExternalResourcesRequired {
@@ -3337,24 +3435,29 @@ abstract class SVGFilterElement
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEMergeNodeElement extends SVGElement {
   def in1: SVGAnimatedString = js.native
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEFloodElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes
 
 @js.native
+@JSGlobal
 abstract class SVGFEFuncAElement extends SVGComponentTransferFunctionElement
 
 @js.native
+@JSGlobal
 abstract class SVGFETileElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def in1: SVGAnimatedString = js.native
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEBlendElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def in2: SVGAnimatedString = js.native
@@ -3365,6 +3468,7 @@ abstract class SVGFEBlendElement
 }
 
 @js.native
+@JSGlobal
 object SVGFEBlendElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGFEBlendElement),List())))) */
   val SVG_FEBLEND_MODE_DARKEN: Int = js.native
@@ -3376,10 +3480,12 @@ object SVGFEBlendElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEMergeElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes
 
 @js.native
+@JSGlobal
 abstract class SVGFEPointLightElement extends SVGElement {
   def y: SVGAnimatedNumber = js.native
 
@@ -3389,6 +3495,7 @@ abstract class SVGFEPointLightElement extends SVGElement {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEGaussianBlurElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def stdDeviationX: SVGAnimatedNumber = js.native
@@ -3415,6 +3522,7 @@ trait SVGFilterPrimitiveStandardAttributes extends SVGStylable {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFESpecularLightingElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def kernelUnitLengthY: SVGAnimatedNumber = js.native
@@ -3431,6 +3539,7 @@ abstract class SVGFESpecularLightingElement
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEMorphologyElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def operator: SVGAnimatedEnumeration = js.native
@@ -3443,6 +3552,7 @@ abstract class SVGFEMorphologyElement
 }
 
 @js.native
+@JSGlobal
 object SVGFEMorphologyElement extends js.Object {
   val SVG_MORPHOLOGY_OPERATOR_UNKNOWN: Int = js.native
   val SVG_MORPHOLOGY_OPERATOR_ERODE: Int = js.native
@@ -3450,9 +3560,11 @@ object SVGFEMorphologyElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEFuncRElement extends SVGComponentTransferFunctionElement
 
 @js.native
+@JSGlobal
 abstract class SVGFEDisplacementMapElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def in2: SVGAnimatedString = js.native
@@ -3467,6 +3579,7 @@ abstract class SVGFEDisplacementMapElement
 }
 
 @js.native
+@JSGlobal
 object SVGFEDisplacementMapElement extends js.Object {
   val SVG_CHANNEL_B: Int = js.native
   val SVG_CHANNEL_R: Int = js.native
@@ -3476,6 +3589,7 @@ object SVGFEDisplacementMapElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGComponentTransferFunctionElement extends SVGElement {
   def tableValues: SVGAnimatedNumberList = js.native
 
@@ -3493,6 +3607,7 @@ abstract class SVGComponentTransferFunctionElement extends SVGElement {
 }
 
 @js.native
+@JSGlobal
 object SVGComponentTransferFunctionElement extends js.Object {
   val SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN: Int = js.native
   val SVG_FECOMPONENTTRANSFER_TYPE_TABLE: Int = js.native
@@ -3503,6 +3618,7 @@ object SVGComponentTransferFunctionElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEDistantLightElement extends SVGElement {
   def azimuth: SVGAnimatedNumber = js.native
 
@@ -3510,9 +3626,11 @@ abstract class SVGFEDistantLightElement extends SVGElement {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEFuncBElement extends SVGComponentTransferFunctionElement
 
 @js.native
+@JSGlobal
 abstract class SVGFETurbulenceElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def baseFrequencyX: SVGAnimatedNumber = js.native
@@ -3529,6 +3647,7 @@ abstract class SVGFETurbulenceElement
 }
 
 @js.native
+@JSGlobal
 object SVGFETurbulenceElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGFETurbulenceElement),List())))) */
   val SVG_STITCHTYPE_UNKNOWN: Int = js.native
@@ -3540,9 +3659,11 @@ object SVGFETurbulenceElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEFuncGElement extends SVGComponentTransferFunctionElement
 
 @js.native
+@JSGlobal
 abstract class SVGFEColorMatrixElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def in1: SVGAnimatedString = js.native
@@ -3553,6 +3674,7 @@ abstract class SVGFEColorMatrixElement
 }
 
 @js.native
+@JSGlobal
 object SVGFEColorMatrixElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGFEColorMatrixElement),List())))) */
   val SVG_FECOLORMATRIX_TYPE_SATURATE: Int = js.native
@@ -3563,6 +3685,7 @@ object SVGFEColorMatrixElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFESpotLightElement extends SVGElement {
   def pointsAtY: SVGAnimatedNumber = js.native
 
@@ -3582,6 +3705,7 @@ abstract class SVGFESpotLightElement extends SVGElement {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEOffsetElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def dy: SVGAnimatedNumber = js.native
@@ -3592,6 +3716,7 @@ abstract class SVGFEOffsetElement
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEImageElement
     extends SVGElement with SVGLangSpace
     with SVGFilterPrimitiveStandardAttributes with SVGURIReference
@@ -3600,6 +3725,7 @@ abstract class SVGFEImageElement
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFECompositeElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def operator: SVGAnimatedEnumeration = js.native
@@ -3618,6 +3744,7 @@ abstract class SVGFECompositeElement
 }
 
 @js.native
+@JSGlobal
 object SVGFECompositeElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGFECompositeElement),List())))) */
   val SVG_FECOMPOSITE_OPERATOR_OUT: Int = js.native
@@ -3630,12 +3757,14 @@ object SVGFECompositeElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEComponentTransferElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def in1: SVGAnimatedString = js.native
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEDiffuseLightingElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def kernelUnitLengthY: SVGAnimatedNumber = js.native
@@ -3650,6 +3779,7 @@ abstract class SVGFEDiffuseLightingElement
 }
 
 @js.native
+@JSGlobal
 object SVGFEConvolveMatrixElement extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(SVGFEConvolveMatrixElement),List())))) */
   val SVG_EDGEMODE_WRAP: Int = js.native
@@ -3659,6 +3789,7 @@ object SVGFEConvolveMatrixElement extends js.Object {
 }
 
 @js.native
+@JSGlobal
 abstract class SVGFEConvolveMatrixElement
     extends SVGElement with SVGFilterPrimitiveStandardAttributes {
   def orderY: SVGAnimatedInteger = js.native

--- a/src/main/scala/org/scalajs/dom/raw/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebGL.scala
@@ -7,12 +7,14 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 import scala.scalajs.js.typedarray._
 
 /**
  * Contains drawing surface attributes.
  */
 @js.native
+@JSGlobal
 class WebGLContextAttributes extends js.Object {
 
   /**
@@ -52,48 +54,56 @@ class WebGLContextAttributes extends js.Object {
  * An opaque type representing a WebGL buffer.
  */
 @js.native
+@JSGlobal
 class WebGLBuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL framebuffer.
  */
 @js.native
+@JSGlobal
 class WebGLFramebuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL program.
  */
 @js.native
+@JSGlobal
 class WebGLProgram private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL renderbuffer.
  */
 @js.native
+@JSGlobal
 class WebGLRenderbuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL shader.
  */
 @js.native
+@JSGlobal
 class WebGLShader private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL texture.
  */
 @js.native
+@JSGlobal
 class WebGLTexture private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL uniform location.
  */
 @js.native
+@JSGlobal
 class WebGLUniformLocation private[this] () extends js.Object
 
 /**
  * Holds information returned by [[WebGLRenderingContext#getActiveAttrib]] and [[WebGLRenderingContext#getActiveUniform]].
  */
 @js.native
+@JSGlobal
 class WebGLActiveInfo private[this] () extends js.Object {
 
   /**
@@ -116,6 +126,7 @@ class WebGLActiveInfo private[this] () extends js.Object {
  * Represents information about the implementation's precision for given parameters.  See [[WebGLRenderingContext#getShaderPrecisionFormat]].
  */
 @js.native
+@JSGlobal
 class WebGLShaderPrecisionFormat private[this] () extends js.Object {
 
   /**
@@ -848,6 +859,7 @@ object WebGLRenderingContext {
 }
 
 @js.native
+@JSGlobal
 class WebGLRenderingContext extends js.Object {
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/WebGL.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebGL.scala
@@ -52,49 +52,49 @@ class WebGLContextAttributes extends js.Object {
  * An opaque type representing a WebGL buffer.
  */
 @js.native
-class WebGLBuffer private () extends js.Object
+class WebGLBuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL framebuffer.
  */
 @js.native
-class WebGLFramebuffer private () extends js.Object
+class WebGLFramebuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL program.
  */
 @js.native
-class WebGLProgram private () extends js.Object
+class WebGLProgram private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL renderbuffer.
  */
 @js.native
-class WebGLRenderbuffer private () extends js.Object
+class WebGLRenderbuffer private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL shader.
  */
 @js.native
-class WebGLShader private () extends js.Object
+class WebGLShader private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL texture.
  */
 @js.native
-class WebGLTexture private () extends js.Object
+class WebGLTexture private[this] () extends js.Object
 
 /**
  * An opaque type representing a WebGL uniform location.
  */
 @js.native
-class WebGLUniformLocation private () extends js.Object
+class WebGLUniformLocation private[this] () extends js.Object
 
 /**
  * Holds information returned by [[WebGLRenderingContext#getActiveAttrib]] and [[WebGLRenderingContext#getActiveUniform]].
  */
 @js.native
-class WebGLActiveInfo private () extends js.Object {
+class WebGLActiveInfo private[this] () extends js.Object {
 
   /**
    * The size of the requested variable.
@@ -116,7 +116,7 @@ class WebGLActiveInfo private () extends js.Object {
  * Represents information about the implementation's precision for given parameters.  See [[WebGLRenderingContext#getShaderPrecisionFormat]].
  */
 @js.native
-class WebGLShaderPrecisionFormat private () extends js.Object {
+class WebGLShaderPrecisionFormat private[this] () extends js.Object {
 
   /**
    * The base 2 log of the absolute value of the minimum value that can be represented.

--- a/src/main/scala/org/scalajs/dom/raw/WebWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/raw/WebWorkers.scala
@@ -37,6 +37,7 @@ trait AbstractWorker extends EventTarget {
  * MDN
  */
 @js.native
+@JSGlobal
 class Worker(stringUrl: String) extends AbstractWorker {
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -10,10 +10,12 @@
 package org.scalajs.dom.raw
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 import scala.scalajs.js.typedarray.ArrayBuffer
 import scala.scalajs.js.|
 
 @js.native
+@JSGlobal
 object XPathResult extends js.Object {
 
   /**
@@ -103,6 +105,7 @@ object XPathResult extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class XPathResult extends js.Object {
   def booleanValue: Boolean = js.native
   def invalidIteratorState: Boolean = js.native
@@ -116,6 +119,7 @@ class XPathResult extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class XPathNSResolver extends js.Object {
   def lookupNamespaceURI(prefix: String): String = js.native
 }
@@ -129,6 +133,7 @@ class XPathNSResolver extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class PositionOptions extends js.Object {
 
   /**
@@ -220,6 +225,7 @@ trait NavigatorID extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class TreeWalker extends js.Object {
 
   /**
@@ -345,6 +351,7 @@ class TreeWalker extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Performance extends js.Object {
 
   /**
@@ -413,6 +420,7 @@ class Performance extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class CompositionEvent extends UIEvent {
 
   /**
@@ -490,6 +498,7 @@ trait WindowTimers extends WindowTimersExtension {
  * MDN
  */
 @js.native
+@JSGlobal
 class Navigator
     extends NavigatorID with NavigatorOnLine with NavigatorContentUtils
     with NavigatorGeolocation with NavigatorStorageUtils with NavigatorLanguage
@@ -517,6 +526,7 @@ trait NodeSelector extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class ClientRect extends js.Object {
   var left: Double = js.native
   var width: Double = js.native
@@ -534,6 +544,7 @@ class ClientRect extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class DOMImplementation extends js.Object {
 
   /**
@@ -652,6 +663,7 @@ trait NonDocumentTypeChildNode extends js.Object {
  * https://developer.mozilla.org/en-US/docs/Web/API/element
  */
 @js.native
+@JSGlobal
 abstract class Element
     extends Node with NodeSelector with ParentNode
     with NonDocumentTypeChildNode {
@@ -940,6 +952,7 @@ abstract class Element
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class Node extends EventTarget {
 
   /**
@@ -1207,6 +1220,7 @@ abstract class Node extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object Node extends js.Object {
   def ENTITY_REFERENCE_NODE: Int = js.native
 
@@ -1319,6 +1333,7 @@ trait HashChangeEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 class MouseEvent extends UIEvent with ModifierKeyEvent {
 
   /**
@@ -1417,6 +1432,7 @@ class MouseEvent extends UIEvent with ModifierKeyEvent {
  * MDN
  */
 @js.native
+@JSGlobal
 class TextMetrics extends js.Object {
 
   /**
@@ -1445,6 +1461,7 @@ trait DocumentEvent extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class CDATASection extends Text
 
 @js.native
@@ -1465,6 +1482,7 @@ trait StyleMedia extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Selection extends js.Object {
 
   /**
@@ -1595,6 +1613,7 @@ class Selection extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class NodeIterator extends js.Object {
 
   /**
@@ -1713,6 +1732,7 @@ trait WindowSessionStorage extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Window
     extends EventTarget with WindowLocalStorage with WindowSessionStorage
     with WindowTimers with WindowBase64 with IDBEnvironment
@@ -2335,6 +2355,7 @@ class Window
  * MDN
  */
 @js.native
+@JSGlobal
 class EventTarget extends js.Object {
 
   /**
@@ -2378,6 +2399,7 @@ class EventTarget extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class CanvasGradient extends js.Object {
 
   /**
@@ -2404,6 +2426,7 @@ class CanvasGradient extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class TouchEvent extends UIEvent with ModifierKeyEvent {
 
   /**
@@ -2452,6 +2475,7 @@ class TouchEvent extends UIEvent with ModifierKeyEvent {
  * MDN
  */
 @js.native
+@JSGlobal
 class TouchList extends DOMList[Touch]
 
 /**
@@ -2466,6 +2490,7 @@ class TouchList extends DOMList[Touch]
  * MDN
  */
 @js.native
+@JSGlobal
 class Touch extends js.Object {
 
   /**
@@ -2593,6 +2618,7 @@ class Touch extends js.Object {
  * W3C
  */
 @js.native
+@JSGlobal
 class KeyboardEvent extends UIEvent with ModifierKeyEvent {
 
   /**
@@ -2661,6 +2687,7 @@ class KeyboardEvent extends UIEvent with ModifierKeyEvent {
 }
 
 @js.native
+@JSGlobal
 object KeyboardEvent extends js.Object {
   def DOM_KEY_LOCATION_RIGHT: Int = js.native
 
@@ -2685,6 +2712,7 @@ object KeyboardEvent extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class Document
     extends Node with NodeSelector with DocumentEvent with ParentNode
     with PageVisibility {
@@ -2987,6 +3015,7 @@ abstract class Document
  * MDN
  */
 @js.native
+@JSGlobal
 class MessageEvent extends Event {
   def source: Window = js.native
 
@@ -3014,6 +3043,7 @@ class MessageEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 class CanvasRenderingContext2D extends js.Object {
 
   /**
@@ -3364,6 +3394,7 @@ class CanvasRenderingContext2D extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class XMLHttpRequest extends EventTarget {
 
   /**
@@ -3540,6 +3571,7 @@ class XMLHttpRequest extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object XMLHttpRequest extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(XMLHttpRequest),List())))) */
   var LOADING: Int = js.native
@@ -3550,6 +3582,7 @@ object XMLHttpRequest extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class Screen extends js.Object {
 
   /**
@@ -3882,6 +3915,7 @@ object ClipboardEventInit {
  * MDN
  */
 @js.native
+@JSGlobal
 class ClipboardEvent(`type`: String, settings: ClipboardEventInit)
     extends Event {
   @deprecated("Use the overload with a ClipboardEventInit instead.", "0.8.1")
@@ -3904,6 +3938,7 @@ class ClipboardEvent(`type`: String, settings: ClipboardEventInit)
  * MDN
  */
 @js.native
+@JSGlobal
 class FocusEvent extends UIEvent {
 
   /**
@@ -3932,6 +3967,7 @@ class FocusEvent extends UIEvent {
  * MDN
  */
 @js.native
+@JSGlobal
 class Range extends js.Object {
 
   /**
@@ -4159,6 +4195,7 @@ class Range extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object Range extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(Range),List())))) */
   val END_TO_END: Int = js.native
@@ -4177,6 +4214,7 @@ object Range extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Storage extends js.Object {
   var length: Int = js.native
 
@@ -4197,6 +4235,7 @@ class Storage extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class DocumentType extends Node {
   def name: String = js.native
 
@@ -4216,6 +4255,7 @@ abstract class DocumentType extends Node {
 
 @deprecated("Obsolete.", "WHATWG DOM")
 @js.native
+@JSGlobal
 class MutationEvent extends Event {
   def newValue: String = js.native
 
@@ -4235,6 +4275,7 @@ class MutationEvent extends Event {
 
 @deprecated("Obsolete.", "WHATWG DOM")
 @js.native
+@JSGlobal
 object MutationEvent extends js.Object {
   val MODIFICATION: Int = js.native
   val REMOVAL: Int = js.native
@@ -4249,6 +4290,7 @@ object MutationEvent extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class MutationObserver(
     callback: js.Function2[js.Array[MutationRecord], MutationObserver, _])
     extends js.Object {
@@ -4477,6 +4519,7 @@ trait DragEvent extends MouseEvent {
  * MDN
  */
 @js.native
+@JSGlobal
 class PerformanceTiming extends js.Object {
 
   /**
@@ -4713,6 +4756,7 @@ trait EventException extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object EventException extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(EventException),List())))) */
   val DISPATCH_REQUEST_ERR: Int = js.native
@@ -4880,6 +4924,7 @@ trait Location extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class PerformanceEntry extends js.Object {
   def name: String = js.native
 
@@ -4896,6 +4941,7 @@ class PerformanceEntry extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class UIEvent extends Event {
 
   /**
@@ -4924,6 +4970,7 @@ class UIEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 class WheelEvent extends MouseEvent {
 
   /**
@@ -4967,6 +5014,7 @@ class WheelEvent extends MouseEvent {
 }
 
 @js.native
+@JSGlobal
 object WheelEvent extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(WheelEvent),List())))) */
   /**
@@ -5005,6 +5053,7 @@ object WheelEvent extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Text extends CharacterData {
 
   /**
@@ -5058,6 +5107,7 @@ trait PositionError extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object PositionError extends js.Object {
 
   val POSITION_UNAVAILABLE: Int = js.native
@@ -5066,6 +5116,7 @@ object PositionError extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class StyleSheetList extends js.Object {
   def length: Int = js.native
 
@@ -5084,6 +5135,7 @@ class StyleSheetList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class CustomEvent extends Event {
 
   /**
@@ -5154,6 +5206,7 @@ trait Geolocation extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class History extends js.Object {
 
   /**
@@ -5252,6 +5305,7 @@ class History extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class TimeRanges extends js.Object {
 
   /**
@@ -5277,6 +5331,7 @@ class TimeRanges extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class BeforeUnloadEvent extends Event {
   def returnValue: String = js.native
 }
@@ -5294,6 +5349,7 @@ class BeforeUnloadEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 class Event extends js.Object {
 
   /**
@@ -5407,6 +5463,7 @@ class Event extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object Event extends js.Object {
   def CAPTURING_PHASE: Int = js.native
 
@@ -5424,6 +5481,7 @@ object Event extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class ImageData extends js.Object {
 
   /**
@@ -5460,6 +5518,7 @@ class ImageData extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class NamedNodeMap extends js.Object {
   def length: Int = js.native
 
@@ -5486,6 +5545,7 @@ class NamedNodeMap extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class MediaList extends js.Object {
   def length: Int = js.native
 
@@ -5513,6 +5573,7 @@ class MediaList extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class ProcessingInstruction extends Node {
   def target: String = js.native
 
@@ -5520,6 +5581,7 @@ abstract class ProcessingInstruction extends Node {
 }
 
 @js.native
+@JSGlobal
 class TextEvent extends UIEvent {
   def inputMethod: Int = js.native
 
@@ -5533,6 +5595,7 @@ class TextEvent extends UIEvent {
 }
 
 @js.native
+@JSGlobal
 object TextEvent extends js.Object {
   val DOM_INPUT_METHOD_KEYBOARD: Int = js.native
   val DOM_INPUT_METHOD_DROP: Int = js.native
@@ -5554,6 +5617,7 @@ object TextEvent extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class DocumentFragment extends Node with NodeSelector
 
 /**
@@ -5588,6 +5652,7 @@ trait Position extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class PerformanceMark extends PerformanceEntry
 
 /**
@@ -5600,6 +5665,7 @@ class PerformanceMark extends PerformanceEntry
  * MDN
  */
 @js.native
+@JSGlobal
 class DOMParser extends js.Object {
   def parseFromString(source: String, mimeType: String): Document = js.native
 }
@@ -5612,6 +5678,7 @@ class DOMParser extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class StyleSheet extends js.Object {
 
   /**
@@ -5683,17 +5750,20 @@ trait DOMList[T] extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class NodeList extends DOMList[Node]
 
 @js.native
 trait NodeListOf[TNode <: Node] extends DOMList[TNode]
 
 @js.native
+@JSGlobal
 class XMLSerializer extends js.Object {
   def serializeToString(target: Node): String = js.native
 }
 
 @js.native
+@JSGlobal
 class PerformanceMeasure extends PerformanceEntry
 
 /**
@@ -5705,6 +5775,7 @@ class PerformanceMeasure extends PerformanceEntry
  * MDN
  */
 @js.native
+@JSGlobal
 class NodeFilter extends js.Object {
 
   /**
@@ -5726,6 +5797,7 @@ class NodeFilter extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object NodeFilter extends js.Object {
 
   val SHOW_ENTITY_REFERENCE: Int = js.native
@@ -5770,11 +5842,13 @@ object NodeFilter extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class MediaError extends js.Object {
   def code: Int = js.native
 }
 
 @js.native
+@JSGlobal
 object MediaError extends js.Object {
   val MEDIA_ERR_ABORTED: Int = js.native
   val MEDIA_ERR_NETWORK: Int = js.native
@@ -5791,11 +5865,13 @@ object MediaError extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Comment extends CharacterData {
   var text: String = js.native
 }
 
 @js.native
+@JSGlobal
 class PerformanceResourceTiming extends PerformanceEntry {
   def redirectStart: Int = js.native
 
@@ -5828,6 +5904,7 @@ class PerformanceResourceTiming extends PerformanceEntry {
  * MDN
  */
 @js.native
+@JSGlobal
 class CanvasPattern extends js.Object
 
 /**
@@ -5836,6 +5913,7 @@ class CanvasPattern extends js.Object
  * MDN
  */
 @js.native
+@JSGlobal
 class StorageEvent extends Event {
 
   /**
@@ -5899,6 +5977,7 @@ class StorageEvent extends Event {
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class CharacterData extends Node with NonDocumentTypeChildNode {
 
   /**
@@ -5967,6 +6046,7 @@ abstract class CharacterData extends Node with NonDocumentTypeChildNode {
  * MDN
  */
 @js.native
+@JSGlobal
 class DOMException extends js.Object {
 
   /**
@@ -5982,6 +6062,7 @@ class DOMException extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object DOMException extends js.Object {
 
   val HIERARCHY_REQUEST_ERR: Int = js.native
@@ -6019,6 +6100,7 @@ object DOMException extends js.Object {
  * MDN
  */
 @js.native
+@JSGlobal
 class Attr extends Node {
 
   /**
@@ -6071,6 +6153,7 @@ class Attr extends Node {
  * MDN
  */
 @js.native
+@JSGlobal
 class PerformanceNavigation extends js.Object {
 
   /**
@@ -6094,6 +6177,7 @@ class PerformanceNavigation extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object PerformanceNavigation extends js.Object {
 
   val TYPE_RELOAD: Int = js.native
@@ -6120,6 +6204,7 @@ trait LinkStyle extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class ClientRectList extends DOMList[ClientRect]
 
 @js.native
@@ -6206,6 +6291,7 @@ trait DOMTokenList extends DOMList[String] {
 }
 
 @js.native
+@JSGlobal
 class MessageChannel extends js.Object {
   def port2: MessagePort = js.native
 
@@ -6354,6 +6440,7 @@ trait CloseEvent extends Event {
  *                 WebSocket object.
  */
 @js.native
+@JSGlobal
 class WebSocket(var url: String = js.native, var protocol: String = js.native)
     extends EventTarget {
   def this(url: String, protocol: js.Array[String]) = this("", "")
@@ -6445,6 +6532,7 @@ class WebSocket(var url: String = js.native, var protocol: String = js.native)
 }
 
 @js.native
+@JSGlobal
 object WebSocket extends js.Object {
 
   /**
@@ -6480,6 +6568,7 @@ object WebSocket extends js.Object {
  * @param settings
  */
 @js.native
+@JSGlobal
 class EventSource(URL: String, settings: js.Dynamic = null)
     extends EventTarget {
 
@@ -6521,6 +6610,7 @@ class EventSource(URL: String, settings: js.Dynamic = null)
 }
 
 @js.native
+@JSGlobal
 object EventSource extends js.Object {
 
   /**
@@ -6621,6 +6711,7 @@ trait FileList extends DOMList[File]
  * MDN
  */
 @js.native
+@JSGlobal
 abstract class File extends Blob {
 
   /**
@@ -6647,6 +6738,7 @@ abstract class File extends Blob {
  * MDN
  */
 @js.native
+@JSGlobal
 object URL extends js.Object {
 
   /**
@@ -6923,6 +7015,7 @@ trait TextTrack extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object TextTrack extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(TextTrack),List())))) */
   var ERROR: Int = js.native
@@ -6993,6 +7086,7 @@ trait MessagePort extends EventTarget {
  * MDN
  */
 @js.native
+@JSGlobal
 class FileReader() extends EventTarget {
 
   /**
@@ -7107,6 +7201,7 @@ class FileReader() extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object FileReader extends js.Object {
   //states
   val EMPTY: Short = js.native
@@ -7143,6 +7238,7 @@ object BlobPropertyBag {
  * MDN
  */
 @js.native
+@JSGlobal
 class Blob(blobParts: js.Array[js.Any] = js.native,
     options: BlobPropertyBag = js.native)
     extends js.Object {
@@ -7169,6 +7265,7 @@ class Blob(blobParts: js.Array[js.Any] = js.native,
 }
 
 @js.native
+@JSGlobal
 object Blob extends js.Object
 
 @js.native
@@ -7192,6 +7289,7 @@ trait ApplicationCache extends EventTarget {
 }
 
 @js.native
+@JSGlobal
 object ApplicationCache extends js.Object {
   /* ??? ConstructorMember(FunSignature(List(),List(),Some(TypeRef(TypeName(ApplicationCache),List())))) */
   val CHECKING: Int = js.native
@@ -7225,6 +7323,7 @@ trait DOMSettableTokenList extends DOMTokenList {
  * MDN
  */
 @js.native
+@JSGlobal
 class FormData(form: HTMLFormElement = js.native) extends js.Object {
 
   /**
@@ -7237,6 +7336,7 @@ class FormData(form: HTMLFormElement = js.native) extends js.Object {
 }
 
 @js.native
+@JSGlobal
 object FormData extends js.Object
 
 /**


### PR DESCRIPTION
This PR contains everything involved in upgrading to Scala.js 0.6.15, piecemeal.

The first commit does the upgrade itself, and configures the compiler to ignore warnings related to major deprecations.

The next 3 commits use [scalafix](https://scalacenter.github.io/scalafix/) to automatically migrate facades to using `@JSGlobal`.

The last commit migrates the examples to use `@JSExportTopLevel` instead of `@JSExport` on top-level objects.