### PR TITLE
Add HTMLTemplateElement interface

### DIFF
--- a/src/main/scala/org/scalajs/dom/html.scala
+++ b/src/main/scala/org/scalajs/dom/html.scala
@@ -86,6 +86,7 @@ object html {
   type TableHeaderCell = raw.HTMLTableHeaderCellElement
   type TableRow = raw.HTMLTableRowElement
   type TableSection = raw.HTMLTableSectionElement
+  type Template = raw.HTMLTemplateElement
   type Title = raw.HTMLTitleElement
   type TextArea = raw.HTMLTextAreaElement
   type Track = raw.HTMLTrackElement

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -4742,19 +4742,19 @@ abstract class HTMLFormElement extends HTMLElement {
 }
 
 /**
-  * The HTMLTemplateElement interface enables access to the contents of an HTML
-  * &lt;template&gt; element; it inherits from properties and methods of the
-  * HTMLElement interface.
-  *
-  * MDN
-  */
+ * The HTMLTemplateElement interface enables access to the contents of an HTML
+ * &lt;template&gt; element; it inherits from properties and methods of the
+ * HTMLElement interface.
+ *
+ * MDN
+ */
 @js.native
 @JSGlobal
 abstract class HTMLTemplateElement extends HTMLElement {
   /**
-    * Returns the &lt;template&gt; element's template contents.
-    *
-    * MDN
-    */
+   * Returns the &lt;template&gt; element's template contents.
+   *
+   * MDN
+   */
   def content: DocumentFragment = js.native
 }

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -4740,3 +4740,21 @@ abstract class HTMLFormElement extends HTMLElement {
 
   def checkValidity(): Boolean = js.native
 }
+
+/**
+  * The HTMLTemplateElement interface enables access to the contents of an HTML
+  * &lt;template&gt; element; it inherits from properties and methods of the
+  * HTMLElement interface.
+  *
+  * MDN
+  */
+@js.native
+@JSGlobal
+abstract class HTMLTemplateElement extends HTMLElement {
+  /**
+    * Returns the &lt;template&gt; element's template contents.
+    *
+    * MDN
+    */
+  def content: DocumentFragment = js.native
+}


### PR DESCRIPTION
Facade for the HTMLTemplateElement interface based on: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement

Also a question: why are read-only properties `def`s and not `val`s ?