### PR TITLE
Add window.scrollX and window.scrollY

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1797,11 +1797,19 @@ class Window
 
   /**
    * Returns the number of pixels that the document has already been scrolled
-   * horizontally.
+   * horizontally. An alias for window.scrollX.
    *
    * MDN
    */
   def pageXOffset: Double = js.native
+
+  /**
+    * Returns the number of pixels that the document has already been scrolled
+    * horizontally.
+    *
+    * MDN
+    */
+  def scrollX: Double = js.native
 
   /**
    * The name of the window is used primarily for setting targets for hyperlinks and
@@ -1981,11 +1989,19 @@ class Window
 
   /**
    * Returns the number of pixels that the document has already been scrolled
-   * vertically.
+   * vertically. An alias for window.scrollY
    *
    * MDN
    */
   def pageYOffset: Double = js.native
+
+  /**
+    * Returns the number of pixels that the document has already been scrolled
+    * vertically.
+    *
+    * MDN
+    */
+  def scrollY: Double = js.native
 
   /**
    * An event handler property for right-click events on the window.

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1989,7 +1989,7 @@ class Window
 
   /**
    * Returns the number of pixels that the document has already been scrolled
-   * vertically. An alias for window.scrollY
+   * vertically. An alias for window.scrollY.
    *
    * MDN
    */


### PR DESCRIPTION
While [`window.pageXOffset`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageXOffset) and [`window.pageYOffset`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset) are implemented, MDN describes them as aliases for the main properties [`window.scrollX`](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX) and [`window.scrollY`](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY), which were not implemented.

As a side note, a quick GitHub search shows that [the alias](https://github.com/search?l=JavaScript&q=%22window.pageXOffset%22&type=Code&utf8=%E2%9C%93) is actually more used than the [primary property](https://github.com/search?l=JavaScript&q=%22window.scrollX%22&type=Code&utf8=%E2%9C%93), but given how common these are, they should both be supported.