### PR TITLE
Add basic support for the Permissions API

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
@@ -1,0 +1,42 @@
+package org.scalajs.dom.experimental
+
+import language.implicitConversions
+import org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.ScalaJSDefined
+
+/**
+  * Implements the Permissions API.
+  *
+  * [[https://www.w3.org/TR/permissions/ W3C Working Draft]]
+  */
+package object permissions {
+
+  @js.native
+  trait PermissionState extends js.Any
+
+  final val `granted` = "granted".asInstanceOf[PermissionState]
+  final val `denied` = "denied".asInstanceOf[PermissionState]
+  final val `prompt` = "prompt".asInstanceOf[PermissionState]
+
+  @ScalaJSDefined
+  trait PermissionStatus extends dom.raw.EventTarget {
+    val state: PermissionState
+    val onchange: js.Function1[PermissionState, _]
+  }
+
+  @ScalaJSDefined
+  trait Permissions extends js.Any {
+    def query(permissionDescriptor: js.Object): js.Promise[PermissionStatus]
+  }
+
+  @ScalaJSDefined
+  trait PermissionsNavigator extends js.Any {
+    val permissions: Permissions
+  }
+
+  implicit def toPermissions(navigator: dom.raw.Navigator): PermissionsNavigator =
+    navigator.asInstanceOf[PermissionsNavigator]
+
+}

--- a/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
@@ -1,10 +1,10 @@
 package org.scalajs.dom.experimental
 
-import language.implicitConversions
+import scala.language.implicitConversions
+
 import org.scalajs.dom
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.ScalaJSDefined
 
 /**
   * Implements the Permissions API.
@@ -16,27 +16,27 @@ package object permissions {
   @js.native
   trait PermissionState extends js.Any
 
-  final val `granted` = "granted".asInstanceOf[PermissionState]
-  final val `denied` = "denied".asInstanceOf[PermissionState]
-  final val `prompt` = "prompt".asInstanceOf[PermissionState]
+  object PermissionState {
+    final val granted = "granted".asInstanceOf[PermissionState]
+    final val denied = "denied".asInstanceOf[PermissionState]
+    final val prompt = "prompt".asInstanceOf[PermissionState]
+  }
 
-  @ScalaJSDefined
   trait PermissionStatus extends dom.raw.EventTarget {
     val state: PermissionState
     val onchange: js.Function1[PermissionState, _]
   }
 
-  @ScalaJSDefined
   trait Permissions extends js.Any {
     def query(permissionDescriptor: js.Object): js.Promise[PermissionStatus]
   }
 
-  @ScalaJSDefined
   trait PermissionsNavigator extends js.Any {
     val permissions: Permissions
   }
 
-  implicit def toPermissions(navigator: dom.raw.Navigator): PermissionsNavigator =
+  implicit def toPermissions(
+      navigator: dom.raw.Navigator): PermissionsNavigator =
     navigator.asInstanceOf[PermissionsNavigator]
 
 }

--- a/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
@@ -7,10 +7,10 @@ import org.scalajs.dom
 import scala.scalajs.js
 
 /**
-  * Implements the Permissions API.
-  *
-  * [[https://www.w3.org/TR/permissions/ W3C Working Draft]]
-  */
+ * Implements the Permissions API.
+ *
+ * [[https://www.w3.org/TR/permissions/ W3C Working Draft]]
+ */
 package object permissions {
 
   @js.native
@@ -27,11 +27,39 @@ package object permissions {
     val onchange: js.Function1[PermissionState, _]
   }
 
-  trait Permissions extends js.Any {
-    def query(permissionDescriptor: js.Object): js.Promise[PermissionStatus]
+  @js.native
+  trait PermissionName extends js.Any
+
+  object PermissionName {
+    val geolocation = "geolocation".asInstanceOf[PermissionName]
+    val midi = "midi".asInstanceOf[PermissionName]
+    val notifications = "notifications".asInstanceOf[PermissionName]
+    val push = "push".asInstanceOf[PermissionName]
+    val `persistent-storage` =
+      "persistent-storage".asInstanceOf[PermissionName]
   }
 
-  trait PermissionsNavigator extends js.Any {
+  trait PermissionDescriptor extends js.Object {
+    val name: PermissionName
+  }
+
+  object PermissionDescriptor {
+    @inline
+    def apply(permissionName: PermissionName): PermissionDescriptor = {
+      js.Dynamic
+        .literal(
+            name = permissionName
+        )
+        .asInstanceOf[PermissionDescriptor]
+    }
+  }
+
+  trait Permissions extends js.Object {
+    def query(
+        permissionDescriptor: PermissionDescriptor): js.Promise[PermissionStatus]
+  }
+
+  trait PermissionsNavigator extends js.Object {
     val permissions: Permissions
   }
 

--- a/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
@@ -17,9 +17,9 @@ package object permissions {
   sealed trait PermissionState extends js.Any
 
   object PermissionState {
-    final val granted = "granted".asInstanceOf[PermissionState]
-    final val denied = "denied".asInstanceOf[PermissionState]
-    final val prompt = "prompt".asInstanceOf[PermissionState]
+    val granted = "granted".asInstanceOf[PermissionState]
+    val denied = "denied".asInstanceOf[PermissionState]
+    val prompt = "prompt".asInstanceOf[PermissionState]
   }
 
   trait PermissionStatus extends dom.raw.EventTarget {
@@ -28,7 +28,7 @@ package object permissions {
   }
 
   @js.native
-  trait PermissionName extends js.Any
+  sealed trait PermissionName extends js.Any
 
   object PermissionName {
     val geolocation = "geolocation".asInstanceOf[PermissionName]

--- a/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/permissions/package.scala
@@ -14,7 +14,7 @@ import scala.scalajs.js
 package object permissions {
 
   @js.native
-  trait PermissionState extends js.Any
+  sealed trait PermissionState extends js.Any
 
   object PermissionState {
     final val granted = "granted".asInstanceOf[PermissionState]
@@ -46,11 +46,9 @@ package object permissions {
   object PermissionDescriptor {
     @inline
     def apply(permissionName: PermissionName): PermissionDescriptor = {
-      js.Dynamic
-        .literal(
-            name = permissionName
-        )
-        .asInstanceOf[PermissionDescriptor]
+      new PermissionDescriptor {
+        val name = permissionName
+      }
     }
   }
 


### PR DESCRIPTION
Supported in Chrome and Firefox. https://developer.mozilla.org/en-US/docs/Web/API/Permissions

Not complete, but usable. 

Example usage:
`navigator.permissions.query(js.Dynamic.literal(name = "geolocation")).toFuture`

