### PR TITLE
HTMLInputElement.valueAsNumber returns Double

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -2569,7 +2569,7 @@ abstract class HTMLInputElement extends HTMLElement {
    *
    * MDN
    */
-  var valueAsNumber: Int = js.native
+  var valueAsNumber: Double = js.native
 
   /**
    * Reflects the placeholder HTML attribute, containing a hint to the user of what can


### PR DESCRIPTION
According to [HTMLInputElement on MDN](https://developer.mozilla.org/de/docs/Web/API/HTMLInputElement#Properties), `valueAsNumber` returns a `Double`.