### PR TITLE
Improve DOM_KEY_LOCATION_* bindings

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -11,7 +11,7 @@ import scala.scalajs.js.typedarray.TypedArrayBufferOps._
 
 import org.scalajs.dom
 import org.scalajs.dom.{FormData, html, raw}
-import org.scalajs.dom.raw.Blob
+import org.scalajs.dom.raw.{Blob, KeyboardEvent}
 
 /**
  * Used to extend out javascript *Collections to make them usable as normal
@@ -226,6 +226,14 @@ object KeyCode {
   @deprecated("Use KeyCode.Y instead", "0.8.1") final val y = Y
   @deprecated("Use KeyCode.Z instead", "0.8.1") final val z = Z
   // format: on
+}
+
+/** Aliases for DOM_KEY_LOCATION_* constants from [[KeyboardEvent]] */
+object KeyLocation {
+  final val Standard = KeyboardEvent.DOM_KEY_LOCATION_STANDARD
+  final val Left = KeyboardEvent.DOM_KEY_LOCATION_LEFT
+  final val Right = KeyboardEvent.DOM_KEY_LOCATION_RIGHT
+  final val NumPad = KeyboardEvent.DOM_KEY_LOCATION_NUMPAD
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2749,10 +2749,6 @@ object KeyboardEvent extends js.Object {
   def DOM_KEY_LOCATION_LEFT: Int = js.native
 
   def DOM_KEY_LOCATION_NUMPAD: Int = js.native
-
-  def DOM_KEY_LOCATION_JOYSTICK: Int = js.native
-
-  def DOM_KEY_LOCATION_MOBILE: Int = js.native
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2659,7 +2659,7 @@ class KeyboardEvent(typeArg: String, keyboardEventInit: KeyboardEventInit)
 
   /**
    * The location of the key on the keyboard or other input device.
-   * See the constants in the KeyboardEvent object.
+   * See the constants in the [[KeyboardEvent]] object.
    *
    * MDN
    */
@@ -2742,12 +2742,54 @@ trait KeyboardEventInit extends js.Object {
 @js.native
 @JSGlobal
 object KeyboardEvent extends js.Object {
-  def DOM_KEY_LOCATION_RIGHT: Int = js.native
 
+  /**
+   * The key has only one version, or can't be distinguished between the left
+   * and right versions of the key, and was not pressed on the numeric keypad
+   * or a key that is considered to be part of the keypad.
+   *
+   * MDN
+   */
   def DOM_KEY_LOCATION_STANDARD: Int = js.native
 
+  /**
+   * The key was the left-hand version of the key; for example, the left-hand
+   * Control key was pressed on a standard 101 key US keyboard. This value is
+   * only used for keys that have more that one possible location on the
+   * keyboard.
+   *
+   * MDN
+   */
   def DOM_KEY_LOCATION_LEFT: Int = js.native
 
+  /**
+   * The key was the right-hand version of the key; for example, the right-hand
+   * Control key is pressed on a standard 101 key US keyboard. This value is
+   * only used for keys that have more that one possible location on the
+   * keyboard.
+   *
+   * MDN
+   */
+  def DOM_KEY_LOCATION_RIGHT: Int = js.native
+
+  /**
+   * The key was on the numeric keypad, or has a virtual key code that
+   * corresponds to the numeric keypad.
+   *
+   * @note When NumLock is locked, Gecko always returns
+   *       [[DOM_KEY_LOCATION_NUMPAD]] for the keys on the numeric pad.
+   *       Otherwise, when NumLock is unlocked and the keyboard actually has
+   *       a numeric keypad, Gecko always returns [[DOM_KEY_LOCATION_NUMPAD]]
+   *       too. On the other hand, if the keyboard doesn't have a keypad, such
+   *       as on a notebook computer, some keys become Numpad only when NumLock
+   *       is locked. When such keys fires key events, the location attribute
+   *       value depends on the key. That is, it must not be
+   *       [[DOM_KEY_LOCATION_NUMPAD]].
+   * @note NumLock key's key events indicate [[DOM_KEY_LOCATION_STANDARD]] both
+   *       on Gecko and Internet Explorer.
+   *
+   * MDN
+   */
   def DOM_KEY_LOCATION_NUMPAD: Int = js.native
 }
 


### PR DESCRIPTION
The current naming of the object `KeyboardEvent` is slightly unfortunate as it only contains constants related to key locations.

Other wrappers call this object `KeyLocation`:

* https://api.dartlang.org/stable/1.24.3/dart-html/KeyLocation-class.html
* https://vaadin.com/api/7.6.5/elemental/events/KeyboardEvent.KeyLocation.html

For compatibility reasons, I kept the object and defined aliases in `ext`.

I was also considering to drop `js.native` since the standard defines the constants as follows: 

```scala
val DOM_KEY_LOCATION_STANDARD = 0x00
val DOM_KEY_LOCATION_LEFT     = 0x01
val DOM_KEY_LOCATION_RIGHT    = 0x02
val DOM_KEY_LOCATION_NUMPAD   = 0x03
```