### PR TITLE
Node: Add contains()

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -1171,6 +1171,15 @@ abstract class Node extends EventTarget {
   def isSameNode(other: Node): Boolean = js.native
 
   /**
+   * Returns a Boolean value indicating whether a node is a descendant of a
+   * given node, i.e. the node itself, one of its direct children (childNodes),
+   * one of the children's direct children, and so on.
+   *
+   * MDN
+   */
+  def contains(otherNode: Node): Boolean = js.native
+
+  /**
    * hasAttributes returns a boolean value of true or false, indicating if the current
    * element has any attributes or not.
    *


### PR DESCRIPTION
The pull request https://github.com/scala-js/scala-js-dom/pull/64 already attempted to add the `contains()` method, but it does not seem to have been merged. `contains()` is now widely supported by browsers and I presume it is safe to add this function.

See also:
- https://developer.mozilla.org/en-US/docs/Web/API/Node/contains
- https://dom.spec.whatwg.org/#dom-node-contains-other-other