### PR TITLE
Add types for AbortController

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/AbortController.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/AbortController.scala
@@ -48,7 +48,7 @@ trait AbortSignal extends EventTarget {
    *
    * MDN
    */
-  val aborted: Boolean = js.native
+  def aborted: Boolean = js.native
 
   /**
    * Invoked when an abort event fires, i.e. when the DOM request(s) the signal

--- a/src/main/scala/org/scalajs/dom/experimental/AbortController.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/AbortController.scala
@@ -1,0 +1,60 @@
+package org.scalajs.dom.experimental
+
+import org.scalajs.dom.raw.EventTarget
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/**
+ * The AbortController interface represents a controller object that allows you
+ * to abort one or more DOM requests as and when desired.
+ *
+ * MDN
+ */
+@js.native
+@JSGlobal
+class AbortController() extends js.Object {
+
+  /**
+   * Returns a AbortSignal object instance, which can be used to communicate
+   * with/abort a DOM request
+   *
+   * MDN
+   */
+  val signal: AbortSignal = js.native
+
+  /**
+   * Aborts a DOM request before it has completed. This is able to abort fetch
+   * requests, consumption of any response Body, and streams.
+   *
+   * MDN
+   */
+  def abort(): Unit = js.native
+}
+
+/**
+ * The AbortSignal interface represents a signal object that allows you to
+ * communicate with a DOM request (such as a Fetch) and abort it if required
+ * via an AbortController object.
+ *
+ * MDN
+ */
+@js.native
+trait AbortSignal extends EventTarget {
+
+  /**
+   * A Boolean that indicates whether the request(s) the signal is
+   * communicating with is/are aborted (true) or not (false).
+   *
+   * MDN
+   */
+  val aborted: Boolean = js.native
+
+  /**
+   * Invoked when an abort event fires, i.e. when the DOM request(s) the signal
+   * is communicating with is/are aborted.
+   *
+   * MDN
+   */
+  var onabort: js.Function0[Any] = js.native
+}

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -68,6 +68,10 @@ class Request(input: RequestInfo, init: RequestInit = null) extends js.Object {
   def redirect: RequestRedirect = js.native
 
   def integrity: String = js.native //should be DOMString
+
+  val keepalive: Boolean = js.native
+
+  val signal: js.UndefOr[AbortSignal] = js.native
 }
 
 object RequestInit {
@@ -95,10 +99,12 @@ object RequestInit {
       referrerPolicy: js.UndefOr[ReferrerPolicy] = js.undefined,
       mode: js.UndefOr[RequestMode] = js.undefined,
       credentials: js.UndefOr[RequestCredentials] = js.undefined,
-      requestCache: js.UndefOr[RequestCache] = js.undefined,
-      requestRedirect: js.UndefOr[RequestRedirect] = js.undefined,
+      cache: js.UndefOr[RequestCache] = js.undefined,
+      redirect: js.UndefOr[RequestRedirect] = js.undefined,
       integrity: js.UndefOr[String] = js.undefined, //see [[https://w3c
       // .github.io/webappsec-subresource-integrity/ integrity spec]]
+      keepalive: js.UndefOr[Boolean] = js.undefined,
+      signal: js.UndefOr[AbortSignal] = js.undefined,
       window: js.UndefOr[Null] = js.undefined): RequestInit = {
     val result = js.Dynamic.literal()
 
@@ -114,9 +120,11 @@ object RequestInit {
     set("referrerPolicy", referrerPolicy)
     set("mode", mode)
     set("credentials", credentials)
-    set("requestCache", requestCache)
-    set("requestRedirect", requestRedirect)
+    set("cache", cache)
+    set("redirect", redirect)
     set("integrity", integrity)
+    set("keepalive", keepalive)
+    set("signal", signal)
     set("window", window)
 
     result.asInstanceOf[RequestInit]
@@ -143,11 +151,15 @@ trait RequestInit extends js.Object {
 
   var credentials: js.UndefOr[RequestCredentials]
 
-  var requestCache: js.UndefOr[RequestCache]
+  var cache: js.UndefOr[RequestCache]
 
-  var requestRedirect: js.UndefOr[RequestRedirect]
+  var redirect: js.UndefOr[RequestRedirect]
 
   var integrity: js.UndefOr[String]
+
+  var keepalive: js.UndefOr[Boolean]
+
+  var signal: js.UndefOr[AbortSignal]
 
   /**
    * The whatwg spec section on [[https://fetch.spec.whatwg.org/#requestinit RequestInit dictionary]]

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -69,9 +69,9 @@ class Request(input: RequestInfo, init: RequestInit = null) extends js.Object {
 
   def integrity: String = js.native //should be DOMString
 
-  val keepalive: Boolean = js.native
+  def keepalive: Boolean = js.native
 
-  val signal: js.UndefOr[AbortSignal] = js.native
+  def signal: AbortSignal = js.native
 }
 
 object RequestInit {
@@ -92,6 +92,7 @@ object RequestInit {
    * //todo: it would help a lot if there were a way to make this fully type safe
    */
   @inline
+  @deprecated("use `new RequestInit {}` instead", "0.9.7")
   def apply(method: js.UndefOr[HttpMethod] = js.undefined,
       headers: js.UndefOr[HeadersInit] = js.undefined,
       body: js.UndefOr[BodyInit] = js.undefined,
@@ -99,12 +100,10 @@ object RequestInit {
       referrerPolicy: js.UndefOr[ReferrerPolicy] = js.undefined,
       mode: js.UndefOr[RequestMode] = js.undefined,
       credentials: js.UndefOr[RequestCredentials] = js.undefined,
-      cache: js.UndefOr[RequestCache] = js.undefined,
-      redirect: js.UndefOr[RequestRedirect] = js.undefined,
+      requestCache: js.UndefOr[RequestCache] = js.undefined,
+      requestRedirect: js.UndefOr[RequestRedirect] = js.undefined,
       integrity: js.UndefOr[String] = js.undefined, //see [[https://w3c
       // .github.io/webappsec-subresource-integrity/ integrity spec]]
-      keepalive: js.UndefOr[Boolean] = js.undefined,
-      signal: js.UndefOr[AbortSignal] = js.undefined,
       window: js.UndefOr[Null] = js.undefined): RequestInit = {
     val result = js.Dynamic.literal()
 
@@ -120,11 +119,9 @@ object RequestInit {
     set("referrerPolicy", referrerPolicy)
     set("mode", mode)
     set("credentials", credentials)
-    set("cache", cache)
-    set("redirect", redirect)
+    set("cache", requestCache)
+    set("redirect", requestRedirect)
     set("integrity", integrity)
-    set("keepalive", keepalive)
-    set("signal", signal)
     set("window", window)
 
     result.asInstanceOf[RequestInit]


### PR DESCRIPTION
Add AbortController and AbortSignal classes along with adding `signal`
to the Fetch request classes. In addition also add `keepalive` to Fetch
request and fix the names of the `cache` and `redirect` properties.