### PR TITLE
Add moveTo and moveBy to Window

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -2876,7 +2876,6 @@ raw/CanvasRenderingContext2D[JC] def isPointInPath(x: Double, y: Double): Boolea
 raw/CanvasRenderingContext2D[JC] def isPointInPath(x: Double, y: Double, fillRule: String): Boolean
 raw/CanvasRenderingContext2D[JC] def lineTo(x: Double, y: Double): Unit
 raw/CanvasRenderingContext2D[JC] def measureText(text: String): TextMetrics
-raw/CanvasRenderingContext2D[JC] def moveBy(deltaX: Double, deltaY: Double): Unit
 raw/CanvasRenderingContext2D[JC] def moveTo(x: Double, y: Double): Unit
 raw/CanvasRenderingContext2D[JC] def putImageData(imagedata: ImageData, dx: Double, dy: Double, dirtyX: Double?, dirtyY: Double?, dirtyWidth: Double?, dirtyHeight: Double?): Unit
 raw/CanvasRenderingContext2D[JC] def quadraticCurveTo(cpx: Double, cpy: Double, x: Double, y: Double): Unit
@@ -24062,6 +24061,8 @@ raw/Window[JC] def innerWidth: Double
 raw/Window[JC] def length: Int
 raw/Window[JC] def localStorage: Storage
 raw/Window[JC] def matchMedia(mediaQuery: String): MediaQueryList
+raw/Window[JC] def moveBy(deltaX: Int, deltaY: Int): Unit
+raw/Window[JC] def moveTo(x: Int, y: Int): Unit
 raw/Window[JC] def navigator: Navigator
 raw/Window[JC] def open(url: String?, target: String?, features: String?, replace: Boolean?): Window
 raw/Window[JC] def outerHeight: Int
@@ -24077,11 +24078,15 @@ raw/Window[JC] def prompt(message: String, default: String?): String
 raw/Window[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 raw/Window[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 raw/Window[JC] def requestAnimationFrame(callback: js.Function1[Double, _]): Int
+raw/Window[JC] def resizeBy(deltaX: Int, deltaY: Int): Unit
+raw/Window[JC] def resizeTo(width: Int, height: Int): Unit
 raw/Window[JC] def screen: Screen
 raw/Window[JC] def screenY: Int
 raw/Window[JC] def scroll(x: Int, y: Int): Unit
 raw/Window[JC] def scrollBy(x: Int, y: Int): Unit
 raw/Window[JC] def scrollTo(x: Int, y: Int): Unit
+raw/Window[JC] def scrollX: Double
+raw/Window[JC] def scrollY: Double
 raw/Window[JC] def self: Window
 raw/Window[JC] def sessionStorage: Storage
 raw/Window[JC] def setInterval(handler: js.Function0[Any], timeout: Double): Int

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -2876,7 +2876,6 @@ raw/CanvasRenderingContext2D[JC] def isPointInPath(x: Double, y: Double): Boolea
 raw/CanvasRenderingContext2D[JC] def isPointInPath(x: Double, y: Double, fillRule: String): Boolean
 raw/CanvasRenderingContext2D[JC] def lineTo(x: Double, y: Double): Unit
 raw/CanvasRenderingContext2D[JC] def measureText(text: String): TextMetrics
-raw/CanvasRenderingContext2D[JC] def moveBy(deltaX: Double, deltaY: Double): Unit
 raw/CanvasRenderingContext2D[JC] def moveTo(x: Double, y: Double): Unit
 raw/CanvasRenderingContext2D[JC] def putImageData(imagedata: ImageData, dx: Double, dy: Double, dirtyX: Double?, dirtyY: Double?, dirtyWidth: Double?, dirtyHeight: Double?): Unit
 raw/CanvasRenderingContext2D[JC] def quadraticCurveTo(cpx: Double, cpy: Double, x: Double, y: Double): Unit
@@ -24062,6 +24061,8 @@ raw/Window[JC] def innerWidth: Double
 raw/Window[JC] def length: Int
 raw/Window[JC] def localStorage: Storage
 raw/Window[JC] def matchMedia(mediaQuery: String): MediaQueryList
+raw/Window[JC] def moveBy(deltaX: Int, deltaY: Int): Unit
+raw/Window[JC] def moveTo(x: Int, y: Int): Unit
 raw/Window[JC] def navigator: Navigator
 raw/Window[JC] def open(url: String?, target: String?, features: String?, replace: Boolean?): Window
 raw/Window[JC] def outerHeight: Int
@@ -24077,11 +24078,15 @@ raw/Window[JC] def prompt(message: String, default: String?): String
 raw/Window[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 raw/Window[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 raw/Window[JC] def requestAnimationFrame(callback: js.Function1[Double, _]): Int
+raw/Window[JC] def resizeBy(deltaX: Int, deltaY: Int): Unit
+raw/Window[JC] def resizeTo(width: Int, height: Int): Unit
 raw/Window[JC] def screen: Screen
 raw/Window[JC] def screenY: Int
 raw/Window[JC] def scroll(x: Int, y: Int): Unit
 raw/Window[JC] def scrollBy(x: Int, y: Int): Unit
 raw/Window[JC] def scrollTo(x: Int, y: Int): Unit
+raw/Window[JC] def scrollX: Double
+raw/Window[JC] def scrollY: Double
 raw/Window[JC] def self: Window
 raw/Window[JC] def sessionStorage: Storage
 raw/Window[JC] def setInterval(handler: js.Function0[Any], timeout: Double): Int

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2762,6 +2762,20 @@ class Window
    * MDN
    */
   var lostpointercapture: js.Function1[PointerEvent, _] = js.native
+
+  /**
+   * Moves the window to the specified coordinates.
+   *
+   * MDN
+   */
+  def moveTo(x: Int, y: Int): Unit = js.native
+
+  /**
+   * Moves the current window by a specified amount.
+   *
+   * MDN
+   */
+  def moveBy(deltaX: Int, deltaY: Int): Unit = js.native
 }
 
 /**
@@ -3900,13 +3914,6 @@ class CanvasRenderingContext2D extends js.Object {
    * MDN
    */
   def moveTo(x: Double, y: Double): Unit = js.native
-
-  /**
-   * Moves the current window by a specified amount.
-   *
-   * MDN
-   */
-  def moveBy(deltaX: Double, deltaY: Double): Unit = js.native
 
   /**
    * Returns an ImageData object representing the underlying pixel data for the area of

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2776,6 +2776,20 @@ class Window
    * MDN
    */
   def moveBy(deltaX: Int, deltaY: Int): Unit = js.native
+
+  /**
+   * Dynamically resizes window.
+   *
+   * MDN
+   */
+  def resizeTo(width: Int, height: Int): Unit = js.native
+
+  /**
+   * Resizes the current window by a certain amount.
+   *
+   * MDN
+   */
+  def resizeBy(deltaX: Int, deltaY: Int): Unit = js.native
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -2790,6 +2790,26 @@ class Window
    * MDN
    */
   def resizeBy(deltaX: Int, deltaY: Int): Unit = js.native
+
+  /**
+   * The read-only scrollX property of the Window interface returns the number
+   * of pixels that the document is currently scrolled horizontally. This value
+   * is subpixel precise in modern browsers, meaning that it isn't necessarily
+   * a whole number. You can get the number of pixels the document is scrolled
+   * vertically from the scrollY property.
+   *
+   * MDN
+   */
+  def scrollX: Double = js.native
+
+  /**
+   * The read-only scrollY property of the Window interface returns the number
+   * of pixels that the document is currently scrolled vertically. This value
+   * is subpixel precise in modern browsers, meaning that it isn't necessarily
+   * a whole number. You can get the number of pixels the document is scrolled
+   * horizontally from the scrollX property.
+   */
+  def scrollY: Double = js.native
 }
 
 /**


### PR DESCRIPTION
- Add moveTo and moveBy to Window
- Add resizeTo and resizeBy to Window
- Add scrollX and scrollY to Window
- Undo addition of CanvasRenderingContext2D.moveBy

Sorry for the previous PR, it was hastily made.

I also used Int as arguments type for window position related functions (in line with https://github.com/purescript-web/purescript-web-html API). Window positions are integers across all operating systems.

Maybe you can keep this PR open and I can add other missing functions and properties? I'm going through them right now.