### PR TITLE
Fix the result type of a few methods in SVGTextContentElement to Double.

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -1895,7 +1895,7 @@ abstract class SVGTextContentElement
 
   def getExtentOfChar(charnum: Int): SVGRect = js.native
 
-  def getComputedTextLength(): Int = js.native
+  def getComputedTextLength(): Double = js.native
 
   def getSubStringLength(charnum: Int, nchars: Int): Int = js.native
 

--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -1903,7 +1903,7 @@ abstract class SVGTextContentElement
 
   def getNumberOfChars(): Int = js.native
 
-  def getRotationOfChar(charnum: Int): Int = js.native
+  def getRotationOfChar(charnum: Int): Double = js.native
 
   def getEndPositionOfChar(charnum: Int): SVGPoint = js.native
 }

--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -1897,7 +1897,7 @@ abstract class SVGTextContentElement
 
   def getComputedTextLength(): Double = js.native
 
-  def getSubStringLength(charnum: Int, nchars: Int): Int = js.native
+  def getSubStringLength(charnum: Int, nchars: Int): Double = js.native
 
   def selectSubString(charnum: Int, nchars: Int): Unit = js.native
 


### PR DESCRIPTION
``def getComputedTextLength(): Int = js.native``
should be 
def getComputedTextLength(): Double = js.native

https://developer.mozilla.org/en-US/docs/Web/API/SVGTextContentElement