### PR TITLE
Add `navigator.mediaDevices.getUserMedia()`, deprecate old method

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/package.scala
@@ -12,6 +12,23 @@ package object webrtc {
   @js.native
   trait NavigatorMediaStream extends js.Object {
 
+    /**
+     * The MediaDevices getUserMedia() method prompts the user for permission to use a media input
+     * which produces a MediaStream with tracks containing the requested types of media. That stream
+     * can include, for example, a video track (produced by either a hardware or virtual video source
+     * such as a camera, video recording device, screen sharing service, and so forth), an audio track
+     * (similarly, produced by a physical or virtual audio source like a microphone, A/D converter, or
+     * the like), and possibly other track types.
+     *
+     * MDN
+     *
+     * @see [[https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia]]
+     */
+    def mediaDevices: MediaDevices
+
+    @deprecated(
+        "Navigator.getUserMedia() is deprecated, use Navigator.mediaDevices.getUserMedia() instead.",
+        "2014-05-28")
     def getUserMedia(constraints: MediaStreamConstraints,
         success: js.Function1[MediaStream, Any],
         error: js.Function1[DOMError, Any]): Unit = js.native

--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/package.scala
@@ -13,18 +13,14 @@ package object webrtc {
   trait NavigatorMediaStream extends js.Object {
 
     /**
-     * The MediaDevices getUserMedia() method prompts the user for permission to use a media input
-     * which produces a MediaStream with tracks containing the requested types of media. That stream
-     * can include, for example, a video track (produced by either a hardware or virtual video source
-     * such as a camera, video recording device, screen sharing service, and so forth), an audio track
-     * (similarly, produced by a physical or virtual audio source like a microphone, A/D converter, or
-     * the like), and possibly other track types.
+     * The Navigator.mediaDevices read-only property returns a MediaDevices object, which provides access to connected
+     * media input devices like cameras and microphones, as well as screen sharing.
      *
      * MDN
      *
-     * @see [[https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia]]
+     * @see [[https://developer.mozilla.org/en-US/docs/Web/API/Navigator/mediaDevices]]
      */
-    def mediaDevices: MediaDevices
+    def mediaDevices: MediaDevices = js.native
 
     @deprecated(
         "Navigator.getUserMedia() is deprecated, use Navigator.mediaDevices.getUserMedia() instead.",


### PR DESCRIPTION
The `navigator.getUserMedia()` method is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia), and in fact during [our hackday](https://twitter.com/rtyley/status/1067815067780087808), I found that I could gain Firefox support just by using the `navigator.mediaDevices.getUserMedia()` method instead, which is [documented](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Browser_compatibility
) as having good cross-browser support. The deprecation seems to have occurred around [28th May 2014](https://github.com/w3c/mediacapture-main/commit/de3bdaf83d2cc1350cc3be970baf1d11219add1d#diff-ea76d38900f79cfae8f60e5f7cf16dd1R2755).


