### PR TITLE
fix(idb): Transaction mode constants are no longer supported

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -412,3 +412,39 @@ object TouchEvents {
   implicit def WindowToTouchEvents(window: raw.Window): TouchEvents =
     window.asInstanceOf[TouchEvents]
 }
+
+/**
+ * Provides constants for IDB Transaction modes
+ * These constants have been removed from browser support
+ * and replaced by String values
+ */
+object IDBTransactionModes {
+
+  type IDBTransactionMode = String
+
+  /**
+    * Allows data to be read but not changed.
+    * It is the default transaction mode.
+    *
+    * MDN
+    */
+  val READ_ONLY: IDBTransactionMode = "readonly"
+
+  /**
+    * Allows any operation to be performed, including ones that delete and create object
+    * stores and indexes. This mode is for updating the version number of transactions
+    * that were started using the setVersion() method of IDBDatabase objects.
+    * Transactions of this mode cannot run concurrently with other transactions.
+    *
+    * MDN
+    */
+  val VERSION_CHANGE: IDBTransactionMode = "versionchange"
+
+  /**
+    * Allows reading and writing of data in existing data stores to be changed.
+    *
+    * MDN
+    */
+  val READ_WRITE: IDBTransactionMode = "readwrite"
+
+}

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -2,16 +2,19 @@ package org.scalajs.dom.ext
 
 import java.nio.ByteBuffer
 
-import scala.language.implicitConversions
-import scala.concurrent.{Promise, Future}
+import org.scalajs.dom
+import org.scalajs.dom.FormData
+import org.scalajs.dom.html
+import org.scalajs.dom.raw
+import org.scalajs.dom.raw.Blob
+import org.scalajs.dom.raw.KeyboardEvent
 
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 import scala.scalajs.js.typedarray.TypedArrayBufferOps._
-
-import org.scalajs.dom
-import org.scalajs.dom.{FormData, html, raw}
-import org.scalajs.dom.raw.{Blob, KeyboardEvent}
 
 /**
  * Used to extend out javascript *Collections to make them usable as normal
@@ -76,16 +79,7 @@ object Color {
   val Magenta = Color(255, 0, 255)
   val Yellow = Color(255, 255, 0)
   val Black = Color(0, 0, 0)
-  val all = Seq(
-      White,
-      Red,
-      Green,
-      Blue,
-      Cyan,
-      Magenta,
-      Yellow,
-      Black
-  )
+  val all = Seq(White, Red, Green, Blue, Cyan, Magenta, Yellow, Black)
 }
 
 object Image {
@@ -423,28 +417,28 @@ object IDBTransactionModes {
   type IDBTransactionMode = String
 
   /**
-    * Allows data to be read but not changed.
-    * It is the default transaction mode.
-    *
-    * MDN
-    */
+   * Allows data to be read but not changed.
+   * It is the default transaction mode.
+   *
+   * MDN
+   */
   val READ_ONLY: IDBTransactionMode = "readonly"
 
   /**
-    * Allows any operation to be performed, including ones that delete and create object
-    * stores and indexes. This mode is for updating the version number of transactions
-    * that were started using the setVersion() method of IDBDatabase objects.
-    * Transactions of this mode cannot run concurrently with other transactions.
-    *
-    * MDN
-    */
+   * Allows any operation to be performed, including ones that delete and create object
+   * stores and indexes. This mode is for updating the version number of transactions
+   * that were started using the setVersion() method of IDBDatabase objects.
+   * Transactions of this mode cannot run concurrently with other transactions.
+   *
+   * MDN
+   */
   val VERSION_CHANGE: IDBTransactionMode = "versionchange"
 
   /**
-    * Allows reading and writing of data in existing data stores to be changed.
-    *
-    * MDN
-    */
+   * Allows reading and writing of data in existing data stores to be changed.
+   *
+   * MDN
+   */
   val READ_WRITE: IDBTransactionMode = "readwrite"
 
 }

--- a/src/main/scala/org/scalajs/dom/idb.scala
+++ b/src/main/scala/org/scalajs/dom/idb.scala
@@ -17,6 +17,5 @@ object idb {
   type OpenDBRequest = raw.IDBOpenDBRequest
   type Request = raw.IDBRequest
   type Transaction = raw.IDBTransaction
-  @inline def Transaction = raw.IDBTransaction
   type VersionChangeEvent = raw.IDBVersionChangeEvent
 }

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -535,7 +535,6 @@ class IDBTransaction extends EventTarget {
   def objectStore(name: String): IDBObjectStore = js.native
 }
 
-
 /**
  * The IDBDatabase interface of the IndexedDB API provides asynchronous access
  * to a connection to a database. Use it to create, manipulate, and delete

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -9,6 +9,8 @@
  */
 package org.scalajs.dom.raw
 
+import org.scalajs.dom.ext.IDBTransactionModes.IDBTransactionMode
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -533,34 +535,6 @@ class IDBTransaction extends EventTarget {
   def objectStore(name: String): IDBObjectStore = js.native
 }
 
-@js.native
-@JSGlobal
-object IDBTransaction extends js.Object {
-
-  /**
-   * Allows data to be read but not changed.
-   *
-   * MDN
-   */
-  val READ_ONLY: String = js.native
-
-  /**
-   * Allows any operation to be performed, including ones that delete and create object
-   * stores and indexes. This mode is for updating the version number of transactions
-   * that were started using the setVersion() method of IDBDatabase objects.
-   * Transactions of this mode cannot run concurrently with other transactions.
-   *
-   * MDN
-   */
-  val VERSION_CHANGE: String = js.native
-
-  /**
-   * Allows reading and writing of data in existing data stores to be changed.
-   *
-   * MDN
-   */
-  val READ_WRITE: String = js.native
-}
 
 /**
  * The IDBDatabase interface of the IndexedDB API provides asynchronous access
@@ -648,7 +622,7 @@ class IDBDatabase extends EventTarget {
    * MDN
    */
   def transaction(storeNames: js.Any,
-      mode: String = js.native): IDBTransaction = js.native
+      mode: IDBTransactionMode = js.native): IDBTransaction = js.native
 
   /**
    * As with createObjectStore, this method can be called only within a versionchange


### PR DESCRIPTION
Hi,

IDB transaction mode constants have been replaced by raw String values since FF25 and Chrome 21.

This PR :
Removes theses constants from native API facade.
Adds an helper in ext package to keep these constants instead of providing raw String to the function.

These constants were not working anymore (undefined behavior exception at runtime when used).
So,  removing them should not be an issue.

More info on https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction#Mode_constants

Regards,