### PR TITLE
feat(idb): Update to newer API

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -13111,19 +13111,20 @@ HttpMethod[SO] val QUERY = "QUERY".asInstanceOf[HttpMethod]
 IDBCursor[JC] def advance(count: Int): Unit
 IDBCursor[JC] def continue(key: js.Any = ???): Unit
 IDBCursor[JC] def delete(): IDBRequest
-IDBCursor[JC] def direction: String
+IDBCursor[JC] def direction: IDBCursorDirection
 IDBCursor[JC] def key: js.Any
 IDBCursor[JC] def primaryKey: js.Any
 IDBCursor[JC] def source: js.Any
 IDBCursor[JC] def update(value: js.Any): IDBRequest
-IDBCursor[JO] val NEXT: String
-IDBCursor[JO] val NEXT_NO_DUPLICATE: String
-IDBCursor[JO] val PREV: String
-IDBCursor[JO] val PREV_NO_DUPLICATE: String
+IDBCursorDirection[JT]
+IDBCursorDirection[SO] val NEXT = "next".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val NEXT_UNIQUE = "nextunique".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val PREV = "prev".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val PREV_UNIQUE = "prevunique".asInstanceOf[IDBCursorDirection]
 IDBCursorWithValue[JC] def advance(count: Int): Unit
 IDBCursorWithValue[JC] def continue(key: js.Any = ???): Unit
 IDBCursorWithValue[JC] def delete(): IDBRequest
-IDBCursorWithValue[JC] def direction: String
+IDBCursorWithValue[JC] def direction: IDBCursorDirection
 IDBCursorWithValue[JC] def key: js.Any
 IDBCursorWithValue[JC] def primaryKey: js.Any
 IDBCursorWithValue[JC] def source: js.Any
@@ -13142,7 +13143,7 @@ IDBDatabase[JC] var onerror: js.Function1[Event, _]
 IDBDatabase[JC] var onversionchange: js.Function1[IDBVersionChangeEvent, _]
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-IDBDatabase[JC] def transaction(storeNames: js.Any, mode: String?): IDBTransaction
+IDBDatabase[JC] def transaction(storeNames: js.Any, mode: IDBTransactionMode?): IDBTransaction
 IDBDatabase[JC] def version: Int
 IDBEnvironment[JT] def indexedDB: IDBFactory  (@deprecated in 1.2.0)
 IDBFactory[JC] def cmp(first: js.Any, second: js.Any): Int
@@ -13156,8 +13157,8 @@ IDBIndex[JC] def getKey(key: js.Any): IDBRequest
 IDBIndex[JC] def keyPath: String
 IDBIndex[JC] def name: String
 IDBIndex[JC] def objectStore: IDBObjectStore
-IDBIndex[JC] def openCursor(range: IDBKeyRange?, direction: String?): IDBRequest
-IDBIndex[JC] def openKeyCursor(range: IDBKeyRange?, direction: String?): IDBRequest
+IDBIndex[JC] def openCursor(range: IDBKeyRange?, direction: IDBCursorDirection?): IDBRequest
+IDBIndex[JC] def openKeyCursor(range: IDBKeyRange?, direction: IDBCursorDirection?): IDBRequest
 IDBIndex[JC] def unique: Boolean
 IDBKeyRange[JC] def lower: js.Any
 IDBKeyRange[JC] def lowerOpen: Boolean
@@ -13174,11 +13175,15 @@ IDBObjectStore[JC] def createIndex(name: String, keyPath: String, optionalParame
 IDBObjectStore[JC] def delete(key: js.Any): IDBRequest
 IDBObjectStore[JC] def deleteIndex(indexName: String): Unit
 IDBObjectStore[JC] def get(key: js.Any): IDBRequest
+IDBObjectStore[JC] def getAll(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, count: js.UndefOr[Int] = js.undefined): IDBRequest
+IDBObjectStore[JC] def getAllKeys(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, count: js.UndefOr[Int] = js.undefined): IDBRequest
+IDBObjectStore[JC] def getKey(key: js.Any): IDBRequest
 IDBObjectStore[JC] def index(name: String): IDBIndex
 IDBObjectStore[JC] def indexNames: DOMStringList
 IDBObjectStore[JC] def keyPath: String
 IDBObjectStore[JC] def name: String
-IDBObjectStore[JC] def openCursor(range: js.Any?, direction: String?): IDBRequest
+IDBObjectStore[JC] def openCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, direction: js.UndefOr[IDBCursorDirection] = js.undefined): IDBRequest
+IDBObjectStore[JC] def openKeyCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, direction: js.UndefOr[IDBCursorDirection] = js.undefined): IDBRequest
 IDBObjectStore[JC] def put(value: js.Any, key: js.Any?): IDBRequest
 IDBObjectStore[JC] def transaction: IDBTransaction
 IDBOpenDBRequest[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -13213,16 +13218,17 @@ IDBTransaction[JC] def addEventListener[T <: Event](`type`: String, listener: js
 IDBTransaction[JC] def db: IDBDatabase
 IDBTransaction[JC] def dispatchEvent(evt: Event): Boolean
 IDBTransaction[JC] def error: DOMException
-IDBTransaction[JC] def mode: String
+IDBTransaction[JC] def mode: IDBTransactionMode
 IDBTransaction[JC] def objectStore(name: String): IDBObjectStore
 IDBTransaction[JC] var onabort: js.Function1[Event, _]
 IDBTransaction[JC] var oncomplete: js.Function1[Event, _]
 IDBTransaction[JC] var onerror: js.Function1[Event, _]
 IDBTransaction[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 IDBTransaction[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-IDBTransaction[JO] val READ_ONLY: String
-IDBTransaction[JO] val READ_WRITE: String
-IDBTransaction[JO] val VERSION_CHANGE: String
+IDBTransactionMode[JT]
+IDBTransactionMode[SO] val READ_ONLY = "readonly".asInstanceOf[IDBTransactionMode]
+IDBTransactionMode[SO] val READ_WRITE = "readwrite".asInstanceOf[IDBTransactionMode]
+IDBTransactionMode[SO] val VERSION_CHANGE = "versionchange".asInstanceOf[IDBTransactionMode]
 IDBVersionChangeEvent[JC] def bubbles: Boolean
 IDBVersionChangeEvent[JC] def cancelBubble: Boolean
 IDBVersionChangeEvent[JC] def cancelable: Boolean
@@ -24701,9 +24707,9 @@ idb[SO] type OpenDBRequest = IDBOpenDBRequest
 idb[SO] type Request = IDBRequest
 idb[SO] type Transaction = IDBTransaction
 idb[SO] type VersionChangeEvent = IDBVersionChangeEvent
-idb[SO] def Cursor = IDBCursor
+idb[SO] def CursorDirection = IDBCursorDirection
 idb[SO] def KeyRange = IDBKeyRange
-idb[SO] def Transaction = IDBTransaction
+idb[SO] def TransactionMode = IDBTransactionMode
 package[SO] type BodyInit = Blob | BufferSource | FormData | String
 package[SO] type BufferSource = ArrayBufferView | ArrayBuffer
 package[SO] type ByteString = String
@@ -25001,9 +25007,7 @@ raw[SO] lazy val EventSource: dom.EventSource.type  (@deprecated in 2.0.0)
 raw[SO] lazy val FileReader: dom.FileReader.type  (@deprecated in 2.0.0)
 raw[SO] lazy val FormData: dom.FormData.type  (@deprecated in 2.0.0)
 raw[SO] @deprecated("use dom.HTMLMediaElement instead", "2.0.0") def HTMLMediaElement = dom.HTMLMediaElement  (@deprecated in 2.0.0)
-raw[SO] @deprecated("use dom.IDBCursor instead", "2.0.0") def IDBCursor = dom.IDBCursor  (@deprecated in 2.0.0)
 raw[SO] @deprecated("use dom.IDBKeyRange instead", "2.0.0") def IDBKeyRange = dom.IDBKeyRange  (@deprecated in 2.0.0)
-raw[SO] @deprecated("use dom.IDBTransaction instead", "2.0.0") def IDBTransaction = dom.IDBTransaction  (@deprecated in 2.0.0)
 raw[SO] lazy val KeyboardEvent: dom.KeyboardEvent.type  (@deprecated in 2.0.0)
 raw[SO] lazy val MediaError: dom.MediaError.type  (@deprecated in 2.0.0)
 raw[SO] lazy val MutationObserverInit: dom.MutationObserverInit.type  (@deprecated in 2.0.0)

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -13111,19 +13111,20 @@ HttpMethod[SO] val QUERY = "QUERY".asInstanceOf[HttpMethod]
 IDBCursor[JC] def advance(count: Int): Unit
 IDBCursor[JC] def continue(key: js.Any = ???): Unit
 IDBCursor[JC] def delete(): IDBRequest
-IDBCursor[JC] def direction: String
+IDBCursor[JC] def direction: IDBCursorDirection
 IDBCursor[JC] def key: js.Any
 IDBCursor[JC] def primaryKey: js.Any
 IDBCursor[JC] def source: js.Any
 IDBCursor[JC] def update(value: js.Any): IDBRequest
-IDBCursor[JO] val NEXT: String
-IDBCursor[JO] val NEXT_NO_DUPLICATE: String
-IDBCursor[JO] val PREV: String
-IDBCursor[JO] val PREV_NO_DUPLICATE: String
+IDBCursorDirection[JT]
+IDBCursorDirection[SO] val NEXT = "next".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val NEXT_UNIQUE = "nextunique".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val PREV = "prev".asInstanceOf[IDBCursorDirection]
+IDBCursorDirection[SO] val PREV_UNIQUE = "prevunique".asInstanceOf[IDBCursorDirection]
 IDBCursorWithValue[JC] def advance(count: Int): Unit
 IDBCursorWithValue[JC] def continue(key: js.Any = ???): Unit
 IDBCursorWithValue[JC] def delete(): IDBRequest
-IDBCursorWithValue[JC] def direction: String
+IDBCursorWithValue[JC] def direction: IDBCursorDirection
 IDBCursorWithValue[JC] def key: js.Any
 IDBCursorWithValue[JC] def primaryKey: js.Any
 IDBCursorWithValue[JC] def source: js.Any
@@ -13142,7 +13143,7 @@ IDBDatabase[JC] var onerror: js.Function1[Event, _]
 IDBDatabase[JC] var onversionchange: js.Function1[IDBVersionChangeEvent, _]
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-IDBDatabase[JC] def transaction(storeNames: js.Any, mode: String?): IDBTransaction
+IDBDatabase[JC] def transaction(storeNames: js.Any, mode: IDBTransactionMode?): IDBTransaction
 IDBDatabase[JC] def version: Int
 IDBEnvironment[JT] def indexedDB: IDBFactory  (@deprecated in 1.2.0)
 IDBFactory[JC] def cmp(first: js.Any, second: js.Any): Int
@@ -13156,8 +13157,8 @@ IDBIndex[JC] def getKey(key: js.Any): IDBRequest
 IDBIndex[JC] def keyPath: String
 IDBIndex[JC] def name: String
 IDBIndex[JC] def objectStore: IDBObjectStore
-IDBIndex[JC] def openCursor(range: IDBKeyRange?, direction: String?): IDBRequest
-IDBIndex[JC] def openKeyCursor(range: IDBKeyRange?, direction: String?): IDBRequest
+IDBIndex[JC] def openCursor(range: IDBKeyRange?, direction: IDBCursorDirection?): IDBRequest
+IDBIndex[JC] def openKeyCursor(range: IDBKeyRange?, direction: IDBCursorDirection?): IDBRequest
 IDBIndex[JC] def unique: Boolean
 IDBKeyRange[JC] def lower: js.Any
 IDBKeyRange[JC] def lowerOpen: Boolean
@@ -13174,11 +13175,15 @@ IDBObjectStore[JC] def createIndex(name: String, keyPath: String, optionalParame
 IDBObjectStore[JC] def delete(key: js.Any): IDBRequest
 IDBObjectStore[JC] def deleteIndex(indexName: String): Unit
 IDBObjectStore[JC] def get(key: js.Any): IDBRequest
+IDBObjectStore[JC] def getAll(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, count: js.UndefOr[Int] = js.undefined): IDBRequest
+IDBObjectStore[JC] def getAllKeys(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, count: js.UndefOr[Int] = js.undefined): IDBRequest
+IDBObjectStore[JC] def getKey(key: js.Any): IDBRequest
 IDBObjectStore[JC] def index(name: String): IDBIndex
 IDBObjectStore[JC] def indexNames: DOMStringList
 IDBObjectStore[JC] def keyPath: String
 IDBObjectStore[JC] def name: String
-IDBObjectStore[JC] def openCursor(range: js.Any?, direction: String?): IDBRequest
+IDBObjectStore[JC] def openCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, direction: js.UndefOr[IDBCursorDirection] = js.undefined): IDBRequest
+IDBObjectStore[JC] def openKeyCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined, direction: js.UndefOr[IDBCursorDirection] = js.undefined): IDBRequest
 IDBObjectStore[JC] def put(value: js.Any, key: js.Any?): IDBRequest
 IDBObjectStore[JC] def transaction: IDBTransaction
 IDBOpenDBRequest[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -13213,16 +13218,17 @@ IDBTransaction[JC] def addEventListener[T <: Event](`type`: String, listener: js
 IDBTransaction[JC] def db: IDBDatabase
 IDBTransaction[JC] def dispatchEvent(evt: Event): Boolean
 IDBTransaction[JC] def error: DOMException
-IDBTransaction[JC] def mode: String
+IDBTransaction[JC] def mode: IDBTransactionMode
 IDBTransaction[JC] def objectStore(name: String): IDBObjectStore
 IDBTransaction[JC] var onabort: js.Function1[Event, _]
 IDBTransaction[JC] var oncomplete: js.Function1[Event, _]
 IDBTransaction[JC] var onerror: js.Function1[Event, _]
 IDBTransaction[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 IDBTransaction[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-IDBTransaction[JO] val READ_ONLY: String
-IDBTransaction[JO] val READ_WRITE: String
-IDBTransaction[JO] val VERSION_CHANGE: String
+IDBTransactionMode[JT]
+IDBTransactionMode[SO] val READ_ONLY = "readonly".asInstanceOf[IDBTransactionMode]
+IDBTransactionMode[SO] val READ_WRITE = "readwrite".asInstanceOf[IDBTransactionMode]
+IDBTransactionMode[SO] val VERSION_CHANGE = "versionchange".asInstanceOf[IDBTransactionMode]
 IDBVersionChangeEvent[JC] def bubbles: Boolean
 IDBVersionChangeEvent[JC] def cancelBubble: Boolean
 IDBVersionChangeEvent[JC] def cancelable: Boolean
@@ -24701,9 +24707,9 @@ idb[SO] type OpenDBRequest = IDBOpenDBRequest
 idb[SO] type Request = IDBRequest
 idb[SO] type Transaction = IDBTransaction
 idb[SO] type VersionChangeEvent = IDBVersionChangeEvent
-idb[SO] def Cursor = IDBCursor
+idb[SO] def CursorDirection = IDBCursorDirection
 idb[SO] def KeyRange = IDBKeyRange
-idb[SO] def Transaction = IDBTransaction
+idb[SO] def TransactionMode = IDBTransactionMode
 package[SO] type BodyInit = Blob | BufferSource | FormData | String
 package[SO] type BufferSource = ArrayBufferView | ArrayBuffer
 package[SO] type ByteString = String
@@ -25001,9 +25007,7 @@ raw[SO] lazy val EventSource: dom.EventSource.type  (@deprecated in 2.0.0)
 raw[SO] lazy val FileReader: dom.FileReader.type  (@deprecated in 2.0.0)
 raw[SO] lazy val FormData: dom.FormData.type  (@deprecated in 2.0.0)
 raw[SO] @deprecated("use dom.HTMLMediaElement instead", "2.0.0") def HTMLMediaElement = dom.HTMLMediaElement  (@deprecated in 2.0.0)
-raw[SO] @deprecated("use dom.IDBCursor instead", "2.0.0") def IDBCursor = dom.IDBCursor  (@deprecated in 2.0.0)
 raw[SO] @deprecated("use dom.IDBKeyRange instead", "2.0.0") def IDBKeyRange = dom.IDBKeyRange  (@deprecated in 2.0.0)
-raw[SO] @deprecated("use dom.IDBTransaction instead", "2.0.0") def IDBTransaction = dom.IDBTransaction  (@deprecated in 2.0.0)
 raw[SO] lazy val KeyboardEvent: dom.KeyboardEvent.type  (@deprecated in 2.0.0)
 raw[SO] lazy val MediaError: dom.MediaError.type  (@deprecated in 2.0.0)
 raw[SO] lazy val MutationObserverInit: dom.MutationObserverInit.type  (@deprecated in 2.0.0)

--- a/src/main/scala/org/scalajs/dom/IDBTypes.scala
+++ b/src/main/scala/org/scalajs/dom/IDBTypes.scala
@@ -11,6 +11,45 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+import scala.scalajs.js.|
+
+/**
+ * IndexedDB transaction mode
+ * Provides constants for IDB Transaction modes
+ * These constants have been removed from browser support
+ * and replaced by String values
+ */
+@js.native
+sealed trait IDBTransactionMode extends js.Any
+
+object IDBTransactionMode {
+
+  /**
+   * Allows data to be read but not changed.
+   * It is the default transaction mode.
+   *
+   * MDN
+   */
+  val READ_ONLY = "readonly".asInstanceOf[IDBTransactionMode]
+
+  /**
+   * Allows any operation to be performed, including ones that delete and create object
+   * stores and indexes. This mode is for updating the version number of transactions
+   * that were started using the setVersion() method of IDBDatabase objects.
+   * Transactions of this mode cannot run concurrently with other transactions.
+   *
+   * MDN
+   */
+  val VERSION_CHANGE = "versionchange".asInstanceOf[IDBTransactionMode]
+
+  /**
+   * Allows reading and writing of data in existing data stores to be changed.
+   *
+   * MDN
+   */
+  val READ_WRITE = "readwrite".asInstanceOf[IDBTransactionMode]
+
+}
 
 /**
  * The IDBObjectStore interface of the IndexedDB API represents an object store in
@@ -86,8 +125,25 @@ class IDBObjectStore extends js.Object {
    */
   def put(value: js.Any, key: js.Any = js.native): IDBRequest = js.native
 
-  def openCursor(range: js.Any = js.native,
-      direction: String = js.native): IDBRequest = js.native
+  /**
+   * The method sets the position of the cursor to the appropriate record,
+   * based on the specified direction.
+   *
+   * MDN
+   */
+  def openCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined,
+      direction: js.UndefOr[
+          IDBCursorDirection] = js.undefined): IDBRequest = js.native
+
+  /**
+   * The method sets the position of the cursor to the appropriate key,
+   * based on the specified direction.
+   *
+   * MDN
+   */
+  def openKeyCursor(range: js.UndefOr[IDBKeyRange | js.Any] = js.undefined,
+      direction: js.UndefOr[
+          IDBCursorDirection] = js.undefined): IDBRequest = js.native
 
   /**
    * Note that this method must be called only from a VersionChange transaction mode
@@ -112,6 +168,32 @@ class IDBObjectStore extends js.Object {
    * MDN
    */
   def get(key: js.Any): IDBRequest = js.native
+
+  /**
+   * If a value is successfully found, then a structured clone of it is created and set as
+   * the result of the request object.
+   *
+   * MDN
+   */
+  def getAll(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined,
+      count: js.UndefOr[Int] = js.undefined): IDBRequest = js.native
+
+  /**
+   * If a value is successfully found, then a structured clone of it is created and set as
+   * the result of the request object.
+   *
+   * MDN
+   */
+  def getAllKeys(query: js.UndefOr[IDBKeyRange | js.Any] = js.undefined,
+      count: js.UndefOr[Int] = js.undefined): IDBRequest = js.native
+
+  /**
+   * If a value is successfully found, then a structured clone of it is created and set as
+   * the result of the request object.
+   *
+   * MDN
+   */
+  def getKey(key: js.Any): IDBRequest = js.native
 
   /**
    * returns an IDBRequest object, and, in a separate thread, deletes the current
@@ -230,7 +312,7 @@ class IDBIndex extends js.Object {
    * MDN
    */
   def openKeyCursor(range: IDBKeyRange = js.native,
-      direction: String = js.native): IDBRequest = js.native
+      direction: IDBCursorDirection = js.native): IDBRequest = js.native
 
   /**
    * Returns an IDBRequest object, and, in a separate thread, finds either the value in
@@ -248,7 +330,7 @@ class IDBIndex extends js.Object {
    * MDN
    */
   def openCursor(range: IDBKeyRange = js.native,
-      direction: String = js.native): IDBRequest = js.native
+      direction: IDBCursorDirection = js.native): IDBRequest = js.native
 }
 
 /**
@@ -282,7 +364,7 @@ class IDBCursor extends js.Object {
    *
    * MDN
    */
-  def direction: String = js.native
+  def direction: IDBCursorDirection = js.native
 
   /**
    * Returns the key for the record at the cursor's position. If the cursor is outside its
@@ -336,13 +418,45 @@ class IDBCursor extends js.Object {
 }
 
 @js.native
-@JSGlobal
-object IDBCursor extends js.Object {
+sealed trait IDBCursorDirection extends js.Any
 
-  val PREV: String = js.native
-  val PREV_NO_DUPLICATE: String = js.native
-  val NEXT: String = js.native
-  val NEXT_NO_DUPLICATE: String = js.native
+object IDBCursorDirection {
+
+  /**
+   * The cursor shows all records, including duplicates.
+   * It starts at the upper bound of the key range and moves downwards
+   * (monotonically decreasing in the order of keys).
+   *
+   * MDN
+   */
+  val PREV = "prev".asInstanceOf[IDBCursorDirection]
+
+  /**
+   * The cursor shows all records, excluding duplicates.
+   * If multiple records exist with the same key, only the first one iterated is retrieved.
+   * It starts at the upper bound of the key range and moves downwards.
+   *
+   * MDN
+   */
+  val PREV_UNIQUE = "prevunique".asInstanceOf[IDBCursorDirection]
+
+  /**
+   * The cursor shows all records, including duplicates.
+   * It starts at the lower bound of the key range and moves upwards
+   * (monotonically increasing in the order of keys).
+   *
+   * MDN
+   */
+  val NEXT = "next".asInstanceOf[IDBCursorDirection]
+
+  /**
+   * The cursor shows all records, excluding duplicates.
+   * If multiple records exist with the same key, only the first one iterated is retrieved.
+   * It starts at the lower bound of the key range and moves upwards.
+   *
+   * MDN
+   */
+  val NEXT_UNIQUE = "nextunique".asInstanceOf[IDBCursorDirection]
 }
 
 /**
@@ -476,7 +590,7 @@ class IDBTransaction extends EventTarget {
    *
    * MDN
    */
-  def mode: String = js.native
+  def mode: IDBTransactionMode = js.native
 
   /**
    * Returns a DOMException indicating the type of error that occured when there is an
@@ -518,35 +632,6 @@ class IDBTransaction extends EventTarget {
    * MDN
    */
   def objectStore(name: String): IDBObjectStore = js.native
-}
-
-@js.native
-@JSGlobal
-object IDBTransaction extends js.Object {
-
-  /**
-   * Allows data to be read but not changed.
-   *
-   * MDN
-   */
-  val READ_ONLY: String = js.native
-
-  /**
-   * Allows any operation to be performed, including ones that delete and create object
-   * stores and indexes. This mode is for updating the version number of transactions
-   * that were started using the setVersion() method of IDBDatabase objects.
-   * Transactions of this mode cannot run concurrently with other transactions.
-   *
-   * MDN
-   */
-  val VERSION_CHANGE: String = js.native
-
-  /**
-   * Allows reading and writing of data in existing data stores to be changed.
-   *
-   * MDN
-   */
-  val READ_WRITE: String = js.native
 }
 
 /**
@@ -643,7 +728,7 @@ class IDBDatabase extends EventTarget {
    * MDN
    */
   def transaction(storeNames: js.Any,
-      mode: String = js.native): IDBTransaction = js.native
+      mode: IDBTransactionMode = js.native): IDBTransaction = js.native
 
   /**
    * As with createObjectStore, this method can be called only within a versionchange

--- a/src/main/scala/org/scalajs/dom/idb.scala
+++ b/src/main/scala/org/scalajs/dom/idb.scala
@@ -5,7 +5,7 @@ package org.scalajs.dom
  */
 object idb {
   type Cursor = IDBCursor
-  @inline def Cursor = IDBCursor
+  @inline def CursorDirection = raw.IDBCursorDirection
   type CursorWithValue = IDBCursorWithValue
   type Database = IDBDatabase
   type Factory = IDBFactory
@@ -16,7 +16,7 @@ object idb {
   type OpenDBRequest = IDBOpenDBRequest
   type Request = IDBRequest
   type Transaction = IDBTransaction
-  @inline def Transaction = IDBTransaction
+  @inline def TransactionMode = raw.IDBTransactionMode
   type VersionChangeEvent = IDBVersionChangeEvent
   @deprecated(
       "Removed. This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible. See https://developer.mozilla.org/en-US/docs/Web/API/IDBEnvironment",

--- a/src/main/scala/org/scalajs/dom/idb.scala
+++ b/src/main/scala/org/scalajs/dom/idb.scala
@@ -5,7 +5,7 @@ package org.scalajs.dom
  */
 object idb {
   type Cursor = IDBCursor
-  @inline def CursorDirection = raw.IDBCursorDirection
+  @inline def CursorDirection = IDBCursorDirection
   type CursorWithValue = IDBCursorWithValue
   type Database = IDBDatabase
   type Factory = IDBFactory
@@ -16,7 +16,7 @@ object idb {
   type OpenDBRequest = IDBOpenDBRequest
   type Request = IDBRequest
   type Transaction = IDBTransaction
-  @inline def TransactionMode = raw.IDBTransactionMode
+  @inline def TransactionMode = IDBTransactionMode
   type VersionChangeEvent = IDBVersionChangeEvent
   @deprecated(
       "Removed. This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible. See https://developer.mozilla.org/en-US/docs/Web/API/IDBEnvironment",

--- a/src/main/scala/org/scalajs/dom/raw.scala
+++ b/src/main/scala/org/scalajs/dom/raw.scala
@@ -336,8 +336,6 @@ object raw {
 
   @deprecated("use dom.IDBCursor instead", "2.0.0")
   type IDBCursor = dom.IDBCursor
-  @deprecated("use dom.IDBCursor instead", "2.0.0")
-  @inline def IDBCursor = dom.IDBCursor
   @deprecated("use dom.IDBCursorWithValue instead", "2.0.0")
   type IDBCursorWithValue = dom.IDBCursorWithValue
   @deprecated("use dom.IDBDatabase instead", "2.0.0")
@@ -360,8 +358,6 @@ object raw {
   type IDBRequest = dom.IDBRequest
   @deprecated("use dom.IDBTransaction instead", "2.0.0")
   type IDBTransaction = dom.IDBTransaction
-  @deprecated("use dom.IDBTransaction instead", "2.0.0")
-  @inline def IDBTransaction = dom.IDBTransaction
   @deprecated("use dom.IDBVersionChangeEvent instead", "2.0.0")
   type IDBVersionChangeEvent = dom.IDBVersionChangeEvent
   @deprecated("use dom.ImageBitmap instead", "2.0.0")


### PR DESCRIPTION
IDB DomString constants have been removed from browser API and replaced by raw String values.

Remove IDB DOMString constants that are no more supported and lead to an UndefinedBehaviorError.
Add these constants in a typesafe way.
