### PR TITLE
Fix ambiguous reference to overloaded definition

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -276,7 +276,7 @@ object Ajax {
       } else {
         // fall back to copying the data
         val tempBuffer = ByteBuffer.allocateDirect(data.remaining)
-        val origPosition = data.position
+        val origPosition = data.position()
         tempBuffer.put(data)
         data.position(origPosition)
         tempBuffer.typedArray()


### PR DESCRIPTION
Fixed the below compile error.

```
[error] /home/vagrant/IdeaProjects/scala-js-dom/src/main/scala/org/scalajs/dom/ext/Extensions.scala:279:33: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]         val origPosition = data.position
[error]                                 ^
```

