### PR TITLE
Fix #219: Fix Event constructors.

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
@@ -7,10 +7,9 @@ import scala.scalajs.js.annotation._
 
 @js.native
 @JSGlobal
-class DeviceOrientationEvent(
-    `type`: String,
-    eventInitDict: DeviceOrientationEventInit
-) extends dom.Event {
+class DeviceOrientationEvent(typeArg: String,
+    init: js.UndefOr[DeviceOrientationEventInit])
+    extends dom.Event(typeArg, init) {
 
   /** Z-Axis rotation in degrees. */
   val alpha: Double = js.native
@@ -29,23 +28,23 @@ class DeviceOrientationEvent(
   val absolute: Boolean = js.native
 }
 
-trait DeviceOrientationEventInit extends js.Object {
+trait DeviceOrientationEventInit extends dom.raw.EventInit {
 
   /** Z-Axis rotation in degrees. */
-  val alpha: Double
+  var alpha: js.UndefOr[Double] = js.undefined
 
   /** X-Axis rotation in degrees. */
-  val beta: Double
+  var beta: js.UndefOr[Double] = js.undefined
 
   /** Y-Axis rotation in degrees. */
-  val gamma: Double
+  var gamma: js.UndefOr[Double] = js.undefined
 
   /**
    * If true, this event data is has been produced using sensor fusion from
    * the magnometer and other sensors.  When false- only the gyroscope has
    * been used.
    */
-  val absolute: Boolean
+  var absolute: js.UndefOr[Boolean] = js.undefined
 }
 
 object DeviceOrientationEventInit {
@@ -83,7 +82,9 @@ trait DeviceRotationRate extends js.Any {
 
 @js.native
 @JSGlobal
-class DeviceMotionEvent extends dom.Event {
+class DeviceMotionEvent(typeArg: String,
+    init: js.UndefOr[DeviceMotionEventInit] = js.undefined)
+    extends dom.Event(typeArg, init) {
 
   /** Device acceleration with gravity removed. */
   val acceleration: DeviceAcceleration = js.native
@@ -98,17 +99,18 @@ class DeviceMotionEvent extends dom.Event {
   val interval: Double = js.native
 }
 
-trait DeviceMotionEventInit extends js.Any {
+trait DeviceMotionEventInit extends dom.raw.EventInit {
 
   /** Device acceleration with gravity removed. */
-  val acceleration: DeviceAcceleration
+  val acceleration: js.UndefOr[DeviceAcceleration] = js.undefined
 
   /** Device acceleration including the force of gravity. */
-  val accelerationIncludingGravity: DeviceAcceleration
+  val accelerationIncludingGravity: js.UndefOr[DeviceAcceleration] =
+    js.undefined
 
   /** The rate of rotation. */
-  val rotationRate: DeviceRotationRate
+  val rotationRate: js.UndefOr[DeviceRotationRate] = js.undefined
 
   /** The sampling rate in seconds that data is received from the hardware. */
-  val interval: Double
+  val interval: js.UndefOr[Double] = js.undefined
 }

--- a/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
@@ -1,6 +1,7 @@
 package org.scalajs.dom.experimental.deviceorientation
 
 import org.scalajs.dom
+import org.scalajs.dom.raw.EventInit
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
@@ -28,7 +29,7 @@ class DeviceOrientationEvent(typeArg: String,
   val absolute: Boolean = js.native
 }
 
-trait DeviceOrientationEventInit extends dom.raw.EventInit {
+trait DeviceOrientationEventInit extends EventInit {
 
   /** Z-Axis rotation in degrees. */
   var alpha: js.UndefOr[Double] = js.undefined
@@ -100,7 +101,7 @@ class DeviceMotionEvent(typeArg: String,
   val interval: Double = js.native
 }
 
-trait DeviceMotionEventInit extends dom.raw.EventInit {
+trait DeviceMotionEventInit extends EventInit {
 
   /** Device acceleration with gravity removed. */
   val acceleration: js.UndefOr[DeviceAcceleration] = js.undefined

--- a/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/deviceorientation/DeviceOrientation.scala
@@ -48,6 +48,7 @@ trait DeviceOrientationEventInit extends dom.raw.EventInit {
 }
 
 object DeviceOrientationEventInit {
+  @deprecated("Create new DeviceOrientationEventInit instead", "0.9.8")
   def apply(alpha: Double, beta: Double, gamma: Double,
       absolute: Boolean): DeviceOrientationEventInit = {
     js.Dynamic

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -65,8 +65,8 @@ trait Gamepad extends js.Any {
   val mapping: GamepadMappingType
 }
 
-trait GamepadEventInit extends js.Any {
-  val gamepad: Gamepad
+trait GamepadEventInit extends dom.raw.EventInit {
+  var gamepad: js.UndefOr[Gamepad]
 }
 
 object GamepadEventInit {
@@ -76,7 +76,9 @@ object GamepadEventInit {
 
 @JSGlobal("GamepadEvent")
 @js.native
-class GamepadEvent(init: GamepadEventInit) extends dom.Event {
+class GamepadEvent(typeArg: String,
+    init: js.UndefOr[GamepadEventInit] = js.undefined)
+    extends dom.Event(typeArg, init) {
   val gamepad: Gamepad = js.native
 }
 

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -10,6 +10,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
 import org.scalajs.dom
+import org.scalajs.dom.raw.EventInit
 
 @js.native
 trait GamepadMappingType extends js.Any
@@ -65,7 +66,7 @@ trait Gamepad extends js.Any {
   val mapping: GamepadMappingType
 }
 
-trait GamepadEventInit extends dom.raw.EventInit {
+trait GamepadEventInit extends EventInit {
   var gamepad: js.UndefOr[Gamepad]
 }
 

--- a/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/gamepad/Gamepad.scala
@@ -70,6 +70,7 @@ trait GamepadEventInit extends dom.raw.EventInit {
 }
 
 object GamepadEventInit {
+  @deprecated("Create new ClipboardEventInit instead", "0.9.8")
   def apply(gamepad: Gamepad): GamepadEventInit =
     js.Dynamic.literal("gamepad" -> gamepad).asInstanceOf[GamepadEventInit]
 }

--- a/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
@@ -467,6 +467,7 @@ trait MediaStreamTrackEventInit extends EventInit {
 }
 
 object MediaStreamTrackEventInit {
+  @deprecated("Create new MediaStreamTrackEventInit instead", "0.9.8")
   @inline
   def apply(
       track: js.UndefOr[MediaStreamTrack] = js.undefined

--- a/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/mediastream/MediaStream.scala
@@ -7,7 +7,7 @@ import scala.scalajs.js
 import scala.scalajs.js.|
 import scala.scalajs.js.annotation._
 
-import org.scalajs.dom.raw.{DOMError, Event, EventTarget}
+import org.scalajs.dom.raw.{DOMError, Event, EventInit, EventTarget}
 
 /**
  * The MediaStream
@@ -462,9 +462,8 @@ object MediaStreamConstraints {
   }
 }
 
-@js.native
-trait MediaStreamTrackEventInit extends js.Object {
-  var track: MediaStreamTrack = js.native
+trait MediaStreamTrackEventInit extends EventInit {
+  var track: js.UndefOr[MediaStreamTrack] = js.undefined
 }
 
 object MediaStreamTrackEventInit {
@@ -480,9 +479,9 @@ object MediaStreamTrackEventInit {
 
 @js.native
 @JSGlobal
-class MediaStreamTrackEvent(`type`: String,
-    eventInitDict: MediaStreamTrackEventInit)
-    extends Event {
+class MediaStreamTrackEvent(typeArg: String,
+    init: js.UndefOr[MediaStreamTrackEventInit])
+    extends Event(typeArg, init) {
   val track: MediaStreamTrack = js.native
 }
 

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -468,7 +468,7 @@ class ExtendableMessageEvent(typeArg: String,
 }
 
 trait ServiceWorkerMessageEventInit extends EventInit {
-  var data: js.UndefOr[js.Any] = js.undefined
+  var data: js.UndefOr[Any] = js.undefined
   var origin: js.UndefOr[String] = js.undefined
   var lastEventId: js.UndefOr[String] = js.undefined
   var source: js.UndefOr[ServiceWorker | MessagePort] = js.undefined

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -80,11 +80,11 @@ trait Client extends js.Object {
 trait CanvasProxy extends js.Any {
   def setContext(context: RenderingContext): Unit = js.native
 }
+
 trait FetchEventInit extends EventInit {
   var isReload: js.UndefOr[Boolean] = js.undefined
   var request: js.UndefOr[Request] = js.undefined
   var clientId: js.UndefOr[String] = js.undefined
-
 }
 
 /**
@@ -400,6 +400,7 @@ trait ServiceWorkerContainer extends EventTarget {
    */
   var onmessage: js.Function1[MessageEvent, _] = js.native
 }
+
 trait ExtendableEventInit extends EventInit {}
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -9,7 +9,8 @@ import org.scalajs.dom.experimental.{
 }
 import org.scalajs.dom.raw.{WorkerGlobalScope, ErrorEvent}
 import org.scalajs.dom.webgl.RenderingContext
-import org.scalajs.dom.{Event, EventTarget, MessagePort}
+import org.scalajs.dom.{Event, EventTarget, MessageEvent, MessagePort}
+import org.scalajs.dom.raw.EventInit
 
 @js.native
 sealed trait FrameType extends js.Any
@@ -79,6 +80,12 @@ trait Client extends js.Object {
 trait CanvasProxy extends js.Any {
   def setContext(context: RenderingContext): Unit = js.native
 }
+trait FetchEventInit extends EventInit {
+  var isReload: js.UndefOr[Boolean] = js.undefined
+  var request: js.UndefOr[Request] = js.undefined
+  var clientId: js.UndefOr[String] = js.undefined
+
+}
 
 /**
  * See [[https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent FetchEvent]] on MDN
@@ -88,7 +95,8 @@ trait CanvasProxy extends js.Any {
  */
 @js.native
 @JSGlobal
-class FetchEvent extends Event {
+class FetchEvent(typeArg: String, init: js.UndefOr[FetchEventInit])
+    extends Event(typeArg, init) {
 
   /**
    * Boolean that is true if the event was dispatched with the user's
@@ -102,6 +110,14 @@ class FetchEvent extends Event {
    * The Request that triggered the event handler.
    */
   def request: Request = js.native
+
+  def preloadResponse: js.Promise[Response] = js.native
+
+  def clientId: String = js.native
+
+  def replacesClientId: String = js.native
+
+  def resultingClientId: String = js.native
 
   /**
    * See [[https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith respondWith]]
@@ -382,8 +398,9 @@ trait ServiceWorkerContainer extends EventTarget {
    *
    * MDN
    */
-  var onmessage: js.Function1[ServiceWorkerMessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent, _] = js.native
 }
+trait ExtendableEventInit extends EventInit {}
 
 /**
  * See [[https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/#extendable-event-interface ¶4.4 ExtendableEvent]]
@@ -394,21 +411,21 @@ trait ServiceWorkerContainer extends EventTarget {
  */
 @js.native
 @JSGlobal
-class ExtendableEvent extends Event {
+class ExtendableEvent(typeArg: String, init: js.UndefOr[ExtendableEventInit])
+    extends Event(typeArg, init) {
   def waitUntil(promise: js.Promise[Any]): Unit = js.native
 }
 
-@js.native
-trait ExtendableMessageEventInit extends js.Object {
-  var data: js.Any = js.native
+trait ExtendableMessageEventInit extends ExtendableEventInit {
+  var data: js.UndefOr[js.Any] = js.undefined
 
-  var origin: String = js.native
+  var origin: js.UndefOr[String] = js.undefined
 
-  var lastEventId: String = js.native
+  var lastEventId: js.UndefOr[String] = js.undefined
 
-  var source: Client | ServiceWorker | MessagePort = js.native
+  var source: js.UndefOr[Client | ServiceWorker | MessagePort] = js.undefined
 
-  var ports: js.Array[MessagePort] = js.native
+  var ports: js.UndefOr[js.Array[MessagePort]] = js.undefined
 }
 
 /**
@@ -419,14 +436,14 @@ trait ExtendableMessageEventInit extends js.Object {
  */
 @js.native
 @JSGlobal
-class ExtendableMessageEvent(`type`: String,
-    eventInitDict: ExtendableMessageEventInit)
-    extends ExtendableEvent {
+class ExtendableMessageEvent(typeArg: String,
+    init: js.UndefOr[ExtendableMessageEventInit])
+    extends ExtendableEvent(typeArg, init) {
 
   /**
    * Returns the event's data. It can be any data type.
    */
-  val data: Any = js.native
+  val data: js.Any = js.native
 
   /**
    * Returns the origin of the service worker's environment settings object.
@@ -449,17 +466,12 @@ class ExtendableMessageEvent(`type`: String,
   def ports: js.Array[MessagePort] = js.native
 }
 
-@js.native
-trait ServiceWorkerMessageEventInit extends js.Object {
-  var data: js.Any = js.native
-
-  var origin: String = js.native
-
-  var lastEventId: String = js.native
-
-  var source: ServiceWorker | MessagePort = js.native
-
-  var ports: js.Array[MessagePort] = js.native
+trait ServiceWorkerMessageEventInit extends EventInit {
+  var data: js.UndefOr[js.Any] = js.undefined
+  var origin: js.UndefOr[String] = js.undefined
+  var lastEventId: js.UndefOr[String] = js.undefined
+  var source: js.UndefOr[ServiceWorker | MessagePort] = js.undefined
+  var ports: js.UndefOr[js.Array[MessagePort]] = js.undefined
 }
 
 /**
@@ -474,9 +486,10 @@ trait ServiceWorkerMessageEventInit extends js.Object {
  */
 @js.native
 @JSGlobal
-class ServiceWorkerMessageEvent(`type`: String,
-    eventInitDict: ServiceWorkerMessageEventInit = js.native)
-    extends Event {
+@deprecated("Instead use MessageEvent", "0.9.8")
+class ServiceWorkerMessageEvent(typeArg: String,
+    init: js.UndefOr[ServiceWorkerMessageEventInit] = js.undefined)
+    extends Event(typeArg, init) {
 
   /**
    * Returns the event's data. It can be any data type.
@@ -780,7 +793,7 @@ trait ServiceWorkerGlobalScope extends WorkerGlobalScope {
    *
    * MDN
    */
-  var onmessage: js.Function1[ServiceWorkerMessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent, _] = js.native
 
   /**
    * Forces the waiting service worker to become the active service worker.

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -418,7 +418,7 @@ class ExtendableEvent(typeArg: String, init: js.UndefOr[ExtendableEventInit])
 }
 
 trait ExtendableMessageEventInit extends ExtendableEventInit {
-  var data: js.UndefOr[js.Any] = js.undefined
+  var data: js.UndefOr[Any] = js.undefined
 
   var origin: js.UndefOr[String] = js.undefined
 
@@ -444,7 +444,7 @@ class ExtendableMessageEvent(typeArg: String,
   /**
    * Returns the event's data. It can be any data type.
    */
-  val data: js.Any = js.native
+  val data: Any = js.native
 
   /**
    * Returns the origin of the service worker's environment settings object.

--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
@@ -9,7 +9,9 @@ import scala.scalajs.js.typedarray.{ArrayBufferView, ArrayBuffer}
 import scala.scalajs.js.|
 
 import org.scalajs.dom.Blob
-import org.scalajs.dom.raw.{DOMError, Event, EventTarget, MessageEvent}
+import org.scalajs.dom.raw.{
+  DOMError, Event, EventInit, EventTarget, MessageEvent
+}
 import org.scalajs.dom.experimental.mediastream._
 
 @js.native
@@ -498,8 +500,10 @@ trait RTCDataChannelInit extends js.Object {
  */
 @js.native
 @JSGlobal
-class RTCDataChannelEvent protected () extends Event {
-  def this(eventInitDict: RTCDataChannelEventInit) = this()
+class RTCDataChannelEvent(typeArg: String,
+    init: js.UndefOr[RTCDataChannelEventInit])
+    extends Event(typeArg, init) {
+  def this(init: RTCDataChannelEventInit) = this("datachannel", init)
 
   /**
    * Contains the RTCDataChannel containing the data channel associated with
@@ -510,9 +514,8 @@ class RTCDataChannelEvent protected () extends Event {
   val channel: RTCDataChannel = js.native
 }
 
-@js.native
-trait RTCDataChannelEventInit extends js.Object {
-  val channel: RTCDataChannel = js.native
+trait RTCDataChannelEventInit extends EventInit {
+  var channel: js.UndefOr[RTCDataChannel] = js.undefined
 }
 
 object RTCDataChannelInit {
@@ -635,8 +638,8 @@ trait RTCStatsReport extends js.Object {
 }
 
 @js.native
-trait RTCPeerConnectionIceEventInit extends js.Object {
-  var candidate: RTCIceCandidate = js.native
+trait RTCPeerConnectionIceEventInit extends EventInit {
+  var candidate: js.UndefOr[RTCIceCandidate] = js.undefined
 }
 
 object RTCPeerConnectionIceEventInit {
@@ -659,9 +662,9 @@ object RTCPeerConnectionIceEventInit {
  */
 @js.native
 @JSGlobal
-class RTCPeerConnectionIceEvent(`type`: String,
-    eventInitDict: RTCPeerConnectionIceEventInit)
-    extends Event {
+class RTCPeerConnectionIceEvent(typeArg: String,
+    init: js.UndefOr[RTCPeerConnectionIceEventInit])
+    extends Event(typeArg, init) {
 
   /**
    * Contains the RTCIceCandidate containing the candidate associated with
@@ -775,6 +778,10 @@ object RTCIceGatheringState {
   val complete = "complete".asInstanceOf[RTCIceGatheringState]
 }
 
+trait MediaStreamEventInit extends EventInit {
+  var stream: js.UndefOr[MediaStream] = js.undefined
+}
+
 /**
  * The MediaStreamEvent interface represents events that occurs in relation to a
  * MediaStream. Two events of this type can be thrown:
@@ -784,8 +791,9 @@ object RTCIceGatheringState {
  */
 @js.native
 @JSGlobal
-class MediaStreamEvent(`type`: String, ms: js.Dictionary[js.Any])
-    extends Event {
+@deprecated("Obsolte.", "0.9.8")
+class MediaStreamEvent(typeArg: String, init: js.UndefOr[MediaStreamEventInit])
+    extends Event(typeArg, init) {
   val stream: MediaStream = js.native
 }
 
@@ -917,16 +925,20 @@ class RTCPeerConnection(
    */
   def signalingState: RTCSignalingState = js.native
 
-  /**
-   * Is the event handler called when the addstream event is received. Such an
-   * event is sent when a MediaStream is added to this connection by the
-   * remote peer. The event is sent immediately after the call
-   * RTCPeerConnection.setRemoteDescription() and doesn't wait for the result
-   * of the SDP negotiation.
-   *
-   * MDN
-   */
-  var onaddstream: js.Function1[MediaStreamEvent, Any] = js.native
+//  /**
+//   * Is the event handler called when the addstream event is received. Such an
+//   * event is sent when a MediaStream is added to this connection by the
+//   * remote peer. The event is sent immediately after the call
+//   * RTCPeerConnection.setRemoteDescription() and doesn't wait for the result
+//   * of the SDP negotiation.
+//   *
+//   * MDN
+//   */
+// TODO: Delete or giving up fatal-warning?
+//  @deprecated("Deprecated in favor of ontrack", "0.9.8")
+//  var onaddstream: js.Function1[MediaStreamEvent, Any] = js.native
+
+  var ontrack: js.Function1[MediaStreamTrackEvent, Any] = js.native
 
   /**
    * Is the event handler called when the datachannel event is received. Such
@@ -997,13 +1009,16 @@ class RTCPeerConnection(
    */
   var onpeeridentity: js.Function1[Event, Any] = js.native
 
-  /**
-   * Is the event handler called when the removestream event, sent when a
-   * MediaStream is removed from this connection, is received.
-   *
-   * MDN
-   */
-  var onremovestream: js.Function1[MediaStreamEvent, Any] = js.native
+//  /**
+//   * Is the event handler called when the removestream event, sent when a
+//   * MediaStream is removed from this connection, is received.
+//   *
+//   * MDN
+//   */
+  // TODO: Delete or giving up fatal-warning?
+  //  @deprecated("Deprecated in favor of onremovetrack", "0.9.8")
+  //  var onremovestream: js.Function1[MediaStreamEvent, Any] = js.native
+  var onremovetrack: js.Function1[MediaStreamTrackEvent, Any] = js.native
 
   /**
    * Is the event handler called when the signalingstatechange event, sent when

--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
@@ -637,12 +637,12 @@ trait RTCStatsReport extends js.Object {
   def apply(id: String): RTCStats = js.native
 }
 
-@js.native
 trait RTCPeerConnectionIceEventInit extends EventInit {
   var candidate: js.UndefOr[RTCIceCandidate] = js.undefined
 }
 
 object RTCPeerConnectionIceEventInit {
+  @deprecated("Create new RTCPeerConnectionIceEventInit instead", "0.9.8")
   @inline
   def apply(
       candidate: js.UndefOr[RTCIceCandidate] = js.undefined

--- a/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/webrtc/WebRTC.scala
@@ -925,18 +925,21 @@ class RTCPeerConnection(
    */
   def signalingState: RTCSignalingState = js.native
 
-//  /**
-//   * Is the event handler called when the addstream event is received. Such an
-//   * event is sent when a MediaStream is added to this connection by the
-//   * remote peer. The event is sent immediately after the call
-//   * RTCPeerConnection.setRemoteDescription() and doesn't wait for the result
-//   * of the SDP negotiation.
-//   *
-//   * MDN
-//   */
-// TODO: Delete or giving up fatal-warning?
-//  @deprecated("Deprecated in favor of ontrack", "0.9.8")
-//  var onaddstream: js.Function1[MediaStreamEvent, Any] = js.native
+  /**
+   * Is the event handler called when the addstream event is received. Such an
+   * event is sent when a MediaStream is added to this connection by the
+   * remote peer. The event is sent immediately after the call
+   * RTCPeerConnection.setRemoteDescription() and doesn't wait for the result
+   * of the SDP negotiation.
+   *
+   * MDN
+   */
+  @deprecated("Deprecated in favor of ontrack", "0.9.8")
+  def onaddstream: js.Function1[MediaStreamEvent, Any] = js.native
+
+  @deprecated("Deprecated in favor of ontrack", "0.9.8")
+  def onaddstream_=(
+      handler: js.Function1[MediaStreamEvent, Any]): Unit = js.native
 
   var ontrack: js.Function1[MediaStreamTrackEvent, Any] = js.native
 
@@ -1009,15 +1012,19 @@ class RTCPeerConnection(
    */
   var onpeeridentity: js.Function1[Event, Any] = js.native
 
-//  /**
-//   * Is the event handler called when the removestream event, sent when a
-//   * MediaStream is removed from this connection, is received.
-//   *
-//   * MDN
-//   */
-  // TODO: Delete or giving up fatal-warning?
-  //  @deprecated("Deprecated in favor of onremovetrack", "0.9.8")
-  //  var onremovestream: js.Function1[MediaStreamEvent, Any] = js.native
+  /**
+   * Is the event handler called when the removestream event, sent when a
+   * MediaStream is removed from this connection, is received.
+   *
+   * MDN
+   */
+  @deprecated("Deprecated in favor of onremovetrack", "0.9.8")
+  def onremovestream: js.Function1[MediaStreamEvent, Any] = js.native
+
+  @deprecated("Deprecated in favor of onremovetrack", "0.9.8")
+  def onremovestream_=(
+      handler: js.Function1[MediaStreamEvent, Any]): Unit = js.native
+
   var onremovetrack: js.Function1[MediaStreamTrackEvent, Any] = js.native
 
   /**

--- a/src/main/scala/org/scalajs/dom/raw/Idb.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Idb.scala
@@ -122,6 +122,11 @@ class IDBObjectStore extends js.Object {
   def delete(key: js.Any): IDBRequest = js.native
 }
 
+trait IDBVersionChangeEventInit extends EventInit {
+  var newVersion: js.UndefOr[Int] = js.undefined
+  var oldVersion: js.UndefOr[Int] = js.undefined
+}
+
 /**
  * The specification has changed and some not up-to-date browsers only support the
  * deprecated unique attribute, version, from an early draft version.
@@ -130,7 +135,9 @@ class IDBObjectStore extends js.Object {
  */
 @js.native
 @JSGlobal
-class IDBVersionChangeEvent extends Event {
+class IDBVersionChangeEvent(typeArg: String,
+    init: js.UndefOr[IDBVersionChangeEventInit])
+    extends Event(typeArg, init) {
 
   /**
    * Returns the new version of the database.

--- a/src/main/scala/org/scalajs/dom/raw/Svg.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Svg.scala
@@ -87,9 +87,19 @@ class SVGPathSegCurvetoCubicSmoothAbs extends SVGPathSeg {
   var y2: Double = js.native
 }
 
+trait SVGZoomEventInit extends UIEventInit {
+  var zoomRectScreen: js.UndefOr[SVGRect] = js.undefined
+  var previousScale: js.UndefOr[Double] = js.undefined
+  var newScale: js.UndefOr[Double] = js.undefined
+  var previousTranslate: js.UndefOr[SVGPoint] = js.undefined
+  var newTranslate: js.UndefOr[SVGPoint] = js.undefined
+}
+
 @js.native
 @JSGlobal
-class SVGZoomEvent extends UIEvent {
+@deprecated("Removed from SVG 2.0", "0.9.8")
+class SVGZoomEvent(typeArg: String, init: js.UndefOr[SVGZoomEventInit])
+    extends UIEvent(typeArg, init) {
   def zoomRectScreen: SVGRect = js.native
 
   def previousScale: Double = js.native

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -4822,10 +4822,6 @@ abstract class DocumentType extends Node {
   def publicId: String = js.native
 }
 
-trait MutationEventInit extends EventInit {
-  // TODO
-}
-
 @deprecated("Deprecated in favor of Mutation Observers (W3C DOM4)",
     "WHATWG DOM")
 @js.native

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -3556,7 +3556,7 @@ abstract class Document
 trait MessageEventInit extends EventInit {
   var source: js.UndefOr[Window] = js.undefined
   var origin: js.UndefOr[String] = js.undefined
-  var data: js.UndefOr[String | Blob | ArrayBuffer] = js.undefined
+  var data: js.UndefOr[Any] = js.undefined
 }
 
 /**
@@ -3575,17 +3575,18 @@ class MessageEvent(typeArg: String, init: js.UndefOr[MessageEventInit])
   def origin: String = js.native
 
   /**
-   * The data from the server (`String`, [[Blob]], or `ArrayBuffer`)
+   * The data you want contained in the MessageEvent.
+   *
+   * This can be of any data type, and will default to null if not specified.
    *
    * MDN
    */
-  def data: String | Blob | ArrayBuffer = js.native
+  def data: Any = js.native
 
   @deprecated("Non-standard", "forever")
   def initMessageEvent(typeArg: String, canBubbleArg: Boolean,
-      cancelableArg: Boolean, dataArg: String | Blob | ArrayBuffer,
-      originArg: String, lastEventIdArg: String,
-      sourceArg: Window): Unit = js.native
+      cancelableArg: Boolean, dataArg: Any, originArg: String,
+      lastEventIdArg: String, sourceArg: Window): Unit = js.native
 
   def ports: js.Any = js.native
 }
@@ -5718,7 +5719,7 @@ class StyleSheetList extends js.Object {
 }
 
 trait CustomEventInit extends EventInit {
-  var detailArg: js.UndefOr[js.Any] = js.undefined
+  var detailArg: js.UndefOr[Any] = js.undefined
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -4830,7 +4830,7 @@ trait MutationEventInit extends EventInit {
     "WHATWG DOM")
 @js.native
 @JSGlobal
-class MutationEvent extends Event("", js.undefined) {
+class MutationEvent private[this] extends Event(js.native, js.native) {
   def newValue: String = js.native
 
   def attrChange: Int = js.native

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -4436,18 +4436,17 @@ trait DataTransfer extends js.Object {
   def files: FileList = js.native
 }
 
-@js.native
 trait ClipboardEventInit extends EventInit {
 
   /**
    * The data for this clipboard event.
    */
-  val data: js.UndefOr[String] = js.native
+  var data: js.UndefOr[String] = js.undefined
 
   /**
    * The MIME type of the data.
    */
-  val dataType: js.UndefOr[String] = js.native
+  var dataType: js.UndefOr[String] = js.undefined
 }
 
 object ClipboardEventInit {
@@ -4459,6 +4458,7 @@ object ClipboardEventInit {
    * @param dataType   The MIME type of the data.
    * @return a new ClipBoardEventInit
    */
+  @deprecated("Create new ClipboardEventInit instead", "0.9.8")
   @inline
   def apply(data: js.UndefOr[String] = js.undefined,
       dataType: js.UndefOr[String] = js.undefined): ClipboardEventInit = {
@@ -5932,10 +5932,10 @@ class BeforeUnloadEvent extends Event("") {
 }
 
 trait EventInit extends js.Object {
-  val bubbles: js.UndefOr[Boolean] = js.undefined
-  val cancelable: js.UndefOr[Boolean] = js.undefined
-  val scoped: js.UndefOr[Boolean] = js.undefined
-  val composed: js.UndefOr[Boolean] = js.undefined
+  var bubbles: js.UndefOr[Boolean] = js.undefined
+  var cancelable: js.UndefOr[Boolean] = js.undefined
+  var scoped: js.UndefOr[Boolean] = js.undefined
+  var composed: js.UndefOr[Boolean] = js.undefined
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -4829,8 +4829,7 @@ trait MutationEventInit extends EventInit {
     "WHATWG DOM")
 @js.native
 @JSGlobal
-class MutationEvent(typeArg: String, init: js.UndefOr[MutationEventInit])
-    extends Event(typeArg, init) {
+class MutationEvent extends Event("", js.undefined) {
   def newValue: String = js.native
 
   def attrChange: Int = js.native

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -413,6 +413,11 @@ class Performance extends js.Object {
   def now(): Double = js.native
 }
 
+trait CompositionEventInit extends UIEventInit {
+  var data: js.UndefOr[String] = js.undefined
+  var locale: js.UndefOr[String] = js.undefined
+}
+
 /**
  * The DOM CompositionEvent represents events that occur due to the user indirectly
  * entering text.
@@ -421,7 +426,8 @@ class Performance extends js.Object {
  */
 @js.native
 @JSGlobal
-class CompositionEvent extends UIEvent {
+class CompositionEvent(typeArg: String, init: js.UndefOr[CompositionEventInit])
+    extends UIEvent(typeArg, init) {
 
   /**
    * For compositionstart events, this is the currently selected text that will be
@@ -1317,6 +1323,13 @@ object Node extends js.Object {
   def DOCUMENT_POSITION_PRECEDING: Int = js.native
 }
 
+trait ModifierKeyEventInit extends js.Object {
+  var metaKey: js.UndefOr[Boolean] = js.undefined
+  var altKey: js.UndefOr[Boolean] = js.undefined
+  var ctrlKey: js.UndefOr[Boolean] = js.undefined
+  var shiftKey: js.UndefOr[Boolean] = js.undefined
+}
+
 @js.native
 trait ModifierKeyEvent extends js.Object {
 
@@ -1378,6 +1391,18 @@ trait HashChangeEvent extends Event {
   def oldURL: String = js.native
 }
 
+trait MouseEventInit extends UIEventInit with ModifierKeyEventInit {
+  var screenX: js.UndefOr[Double] = js.undefined
+  var pageX: js.UndefOr[Double] = js.undefined
+  var pageY: js.UndefOr[Double] = js.undefined
+  var clientY: js.UndefOr[Double] = js.undefined
+  var screenY: js.UndefOr[Double] = js.undefined
+  var relatedTarget: js.UndefOr[EventTarget] = js.undefined
+  var button: js.UndefOr[Int] = js.undefined
+  var buttons: js.UndefOr[Int] = js.undefined
+  var clientX: js.UndefOr[Double] = js.undefined
+}
+
 /**
  * The DOM MouseEvent interface represents events that occur due to the user
  * interacting with a pointing device (such as a mouse).
@@ -1392,7 +1417,8 @@ trait HashChangeEvent extends Event {
  */
 @js.native
 @JSGlobal
-class MouseEvent extends UIEvent with ModifierKeyEvent {
+class MouseEvent(typeArg: String, init: js.UndefOr[MouseEventInit])
+    extends UIEvent(typeArg, init) with ModifierKeyEvent {
 
   /**
    * The screenX property provides the X coordinate of the mouse pointer in global
@@ -1511,8 +1537,9 @@ class MouseEvent extends UIEvent with ModifierKeyEvent {
  */
 @js.native
 @JSGlobal
-class PointerEvent(typeArg: String, pointerEventInit: PointerEventInit)
-    extends MouseEvent {
+class PointerEvent(typeArg: String,
+    pointerEventInit: js.UndefOr[PointerEventInit] = js.undefined)
+    extends MouseEvent(typeArg, pointerEventInit) {
 
   def this(typeArg: String) = this(typeArg, js.native)
 
@@ -1637,7 +1664,7 @@ class PointerEvent(typeArg: String, pointerEventInit: PointerEventInit)
   def isPrimary: Boolean = js.native
 }
 
-trait PointerEventInit extends js.Object {
+trait PointerEventInit extends MouseEventInit {
 
   /**
    * Sets value of MouseEvent.pointerId. Defaults to 0.
@@ -2861,6 +2888,12 @@ class CanvasGradient extends js.Object {
   def addColorStop(offset: Double, color: String): Unit = js.native
 }
 
+trait TouchEventInit extends UIEventInit with ModifierKeyEventInit {
+  var changedTouches: js.UndefOr[TouchList] = js.undefined
+  var targetTouches: js.UndefOr[TouchList] = js.undefined
+  var touches: js.UndefOr[TouchList] = js.undefined
+}
+
 /**
  * A TouchEvent represents an event sent when the state of contacts with a
  * touch-sensitive surface changes. This surface can be a touch screen or trackpad,
@@ -2876,7 +2909,8 @@ class CanvasGradient extends js.Object {
  */
 @js.native
 @JSGlobal
-class TouchEvent extends UIEvent with ModifierKeyEvent {
+class TouchEvent(typeArg: String, init: js.UndefOr[TouchEventInit])
+    extends UIEvent(typeArg, init) with ModifierKeyEvent {
 
   /**
    * A TouchList of all the Touch objects representing individual points of contact
@@ -3068,8 +3102,8 @@ class Touch extends js.Object {
  */
 @js.native
 @JSGlobal
-class KeyboardEvent(typeArg: String, keyboardEventInit: KeyboardEventInit)
-    extends UIEvent with ModifierKeyEvent {
+class KeyboardEvent(typeArg: String, init: js.UndefOr[KeyboardEventInit])
+    extends UIEvent(typeArg, init) with ModifierKeyEvent {
 
   def this(typeArg: String) = this(typeArg, js.native)
 
@@ -3127,7 +3161,7 @@ class KeyboardEvent(typeArg: String, keyboardEventInit: KeyboardEventInit)
       locale: String): Unit = js.native
 }
 
-trait KeyboardEventInit extends js.Object {
+trait KeyboardEventInit extends UIEventInit with ModifierKeyEventInit {
 
   /**
    * Sets value of KeyboardEvent.charCode. Defaults to 0.
@@ -3519,6 +3553,12 @@ abstract class Document
   def releaseCapture(): Unit = js.native
 }
 
+trait MessageEventInit extends EventInit {
+  var source: js.UndefOr[Window] = js.undefined
+  var origin: js.UndefOr[String] = js.undefined
+  var data: js.UndefOr[String | Blob | ArrayBuffer] = js.undefined
+}
+
 /**
  * A MessageEvent is sent to clients using WebSockets when data is received from the
  * server. This is delivered to the listener indicated by the WebSocket object's
@@ -3528,7 +3568,8 @@ abstract class Document
  */
 @js.native
 @JSGlobal
-class MessageEvent extends Event {
+class MessageEvent(typeArg: String, init: js.UndefOr[MessageEventInit])
+    extends Event(typeArg, init) {
   def source: Window = js.native
 
   def origin: String = js.native
@@ -3538,12 +3579,13 @@ class MessageEvent extends Event {
    *
    * MDN
    */
-  def data: Any = js.native
+  def data: String | Blob | ArrayBuffer = js.native
 
   @deprecated("Non-standard", "forever")
   def initMessageEvent(typeArg: String, canBubbleArg: Boolean,
-      cancelableArg: Boolean, dataArg: js.Any, originArg: String,
-      lastEventIdArg: String, sourceArg: Window): Unit = js.native
+      cancelableArg: Boolean, dataArg: String | Blob | ArrayBuffer,
+      originArg: String, lastEventIdArg: String,
+      sourceArg: Window): Unit = js.native
 
   def ports: js.Any = js.native
 }
@@ -4395,17 +4437,17 @@ trait DataTransfer extends js.Object {
 }
 
 @js.native
-trait ClipboardEventInit extends js.Object {
+trait ClipboardEventInit extends EventInit {
 
   /**
    * The data for this clipboard event.
    */
-  val data: String = js.native
+  val data: js.UndefOr[String] = js.native
 
   /**
    * The MIME type of the data.
    */
-  val dataType: String = js.native
+  val dataType: js.UndefOr[String] = js.native
 }
 
 object ClipboardEventInit {
@@ -4435,8 +4477,9 @@ object ClipboardEventInit {
  */
 @js.native
 @JSGlobal
-class ClipboardEvent(`type`: String, settings: ClipboardEventInit)
-    extends Event {
+class ClipboardEvent(typeArg: String,
+    init: js.UndefOr[ClipboardEventInit] = js.undefined)
+    extends Event(typeArg, init) {
   @deprecated("Use the overload with a ClipboardEventInit instead.", "0.8.1")
   def this(`type`: String, settings: js.Dynamic) =
     this(`type`, settings.asInstanceOf[ClipboardEventInit])
@@ -4450,6 +4493,10 @@ class ClipboardEvent(`type`: String, settings: ClipboardEventInit)
   def clipboardData: DataTransfer = js.native
 }
 
+trait FocusEventInit extends UIEventInit {
+  val relatedTarget: js.UndefOr[EventTarget] = js.undefined
+}
+
 /**
  * The FocusEvent interface represents focus-related events like focus, blur,
  * focusin, or focusout.
@@ -4458,7 +4505,9 @@ class ClipboardEvent(`type`: String, settings: ClipboardEventInit)
  */
 @js.native
 @JSGlobal
-class FocusEvent extends UIEvent {
+class FocusEvent(typeArg: String,
+    init: js.UndefOr[FocusEventInit] = js.undefined)
+    extends UIEvent(typeArg, init) {
 
   /**
    * The FocusEvent.relatedTarget read-only property represents a secondary target
@@ -4469,7 +4518,7 @@ class FocusEvent extends UIEvent {
    */
   def relatedTarget: EventTarget = js.native
 
-  @deprecated("Non-standard", "forever")
+  @deprecated("Nonstandard. Instead use constructor to initialize", "forever")
   def initFocusEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window, detailArg: Int,
       relatedTargetArg: EventTarget): Unit = js.native
@@ -4772,10 +4821,16 @@ abstract class DocumentType extends Node {
   def publicId: String = js.native
 }
 
-@deprecated("Obsolete.", "WHATWG DOM")
+trait MutationEventInit extends EventInit {
+  // TODO
+}
+
+@deprecated("Deprecated in favor of Mutation Observers (W3C DOM4)",
+    "WHATWG DOM")
 @js.native
 @JSGlobal
-class MutationEvent extends Event {
+class MutationEvent(typeArg: String, init: js.UndefOr[MutationEventInit])
+    extends Event(typeArg, init) {
   def newValue: String = js.native
 
   def attrChange: Int = js.native
@@ -5454,6 +5509,11 @@ class PerformanceEntry extends js.Object {
   def entryType: String = js.native
 }
 
+trait UIEventInit extends EventInit {
+  val detail: js.UndefOr[Int] = js.undefined
+  val view: js.UndefOr[Window] = js.undefined
+}
+
 /**
  * The DOM UIEvent represents simple user interface events.
  *
@@ -5461,7 +5521,8 @@ class PerformanceEntry extends js.Object {
  */
 @js.native
 @JSGlobal
-class UIEvent extends Event {
+class UIEvent(typeArg: String, init: js.UndefOr[UIEventInit] = js.undefined)
+    extends Event(typeArg, init) {
 
   /**
    * Detail about the event, depending on the type of event. Read only.
@@ -5477,9 +5538,17 @@ class UIEvent extends Event {
    */
   def view: Window = js.native
 
+  @deprecated("Instead use constructor to initialize", "0.9.8")
   def initUIEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, viewArg: Window,
       detailArg: Int): Unit = js.native
+}
+
+trait WheelEventInit extends MouseEventInit {
+  var deltaZ: js.UndefOr[Double] = js.undefined
+  var deltaX: js.UndefOr[Double] = js.undefined
+  var deltaY: js.UndefOr[Double] = js.undefined
+  var deltaMode: js.UndefOr[Int] = js.undefined
 }
 
 /**
@@ -5490,7 +5559,8 @@ class UIEvent extends Event {
  */
 @js.native
 @JSGlobal
-class WheelEvent extends MouseEvent {
+class WheelEvent(typeArg: String, init: js.UndefOr[WheelEventInit])
+    extends MouseEvent(typeArg, init) {
 
   /**
    * Scroll amount for the z-axis. Read only.
@@ -5648,6 +5718,10 @@ class StyleSheetList extends js.Object {
   def update(index: Int, v: StyleSheet): Unit = js.native
 }
 
+trait CustomEventInit extends EventInit {
+  var detailArg: js.UndefOr[js.Any] = js.undefined
+}
+
 /**
  * The DOM CustomEvent are events initialized by an application for any purpose.
  *
@@ -5655,7 +5729,8 @@ class StyleSheetList extends js.Object {
  */
 @js.native
 @JSGlobal
-class CustomEvent extends Event {
+class CustomEvent(typeArg: String, init: js.UndefOr[CustomEventInit])
+    extends Event(typeArg, init) {
 
   /**
    * The data passed when initializing the event.
@@ -5670,6 +5745,7 @@ class CustomEvent extends Event {
    *
    * MDN
    */
+  @deprecated("Instead use constructor", "0.9.8")
   def initCustomEvent(typeArg: String, canBubbleArg: Boolean,
       cancelableArg: Boolean, detailArg: Any): Unit = js.native
 }
@@ -5851,8 +5927,15 @@ class TimeRanges extends js.Object {
 
 @js.native
 @JSGlobal
-class BeforeUnloadEvent extends Event {
+class BeforeUnloadEvent extends Event("") {
   var returnValue: String = js.native
+}
+
+trait EventInit extends js.Object {
+  val bubbles: js.UndefOr[Boolean] = js.undefined
+  val cancelable: js.UndefOr[Boolean] = js.undefined
+  val scoped: js.UndefOr[Boolean] = js.undefined
+  val composed: js.UndefOr[Boolean] = js.undefined
 }
 
 /**
@@ -5869,7 +5952,8 @@ class BeforeUnloadEvent extends Event {
  */
 @js.native
 @JSGlobal
-class Event extends js.Object {
+class Event(typeArg: String, init: js.UndefOr[EventInit] = js.undefined)
+    extends js.Object {
 
   /**
    * Returns the time (in milliseconds since the epoch) at which the event was created.
@@ -6099,9 +6183,16 @@ abstract class ProcessingInstruction extends Node {
   def data: String = js.native
 }
 
+trait TextEventInit extends UIEventInit {
+  var inputMethod: js.UndefOr[Int] = js.undefined
+  var data: js.UndefOr[String] = js.undefined
+  var locale: js.UndefOr[String] = js.undefined
+}
+
 @js.native
 @JSGlobal
-class TextEvent extends UIEvent {
+class TextEvent(typeArg: String, init: js.UndefOr[TextEventInit])
+    extends UIEvent(typeArg, init) {
   def inputMethod: Int = js.native
 
   def data: String = js.native
@@ -6426,6 +6517,14 @@ class PerformanceResourceTiming extends PerformanceEntry {
 @JSGlobal
 class CanvasPattern extends js.Object
 
+trait StorageEventInit extends EventInit {
+  var oldValue: js.UndefOr[String] = js.undefined
+  var newValue: js.UndefOr[String] = js.undefined
+  var url: js.UndefOr[String] = js.undefined
+  var storageArea: js.UndefOr[Storage] = js.undefined
+  var key: js.UndefOr[String] = js.undefined
+}
+
 /**
  * A StorageEvent is sent to a window when a storage area changes.
  *
@@ -6433,7 +6532,8 @@ class CanvasPattern extends js.Object
  */
 @js.native
 @JSGlobal
-class StorageEvent extends Event {
+class StorageEvent(typeArg: String, init: js.UndefOr[StorageEventInit])
+    extends Event(typeArg, init) {
 
   /**
    * The original value of the key. The oldValue is null when the change has been invoked

--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -5927,7 +5927,7 @@ class TimeRanges extends js.Object {
 
 @js.native
 @JSGlobal
-class BeforeUnloadEvent extends Event("") {
+class BeforeUnloadEvent extends Event(js.native) {
   var returnValue: String = js.native
 }
 

--- a/src/main/scala/org/scalajs/dom/svg.scala
+++ b/src/main/scala/org/scalajs/dom/svg.scala
@@ -169,5 +169,6 @@ object svg {
 
   type ZoomAndPan = raw.SVGZoomAndPan
   @inline def ZoomAndPan = raw.SVGZoomAndPan
+  @deprecated("Removed from SVG 2.0", "0.9.8")
   type ZoomEvent = raw.SVGZoomEvent
 }


### PR DESCRIPTION
Closes #219

* Add valid constructors that accept type name and init, as well as type-safe constructor options `***EventInit`
* Removes invalid default (0 args) constructors since `new ***Event()` raises RuntimeError due to lack of required argument
* Add `@deprecated` based on MDN


