### PR TITLE
Fix Travis JDK8 installation failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: xenial
 language: scala
 script:
   - sbt ++$TRAVIS_SCALA_VERSION package doc example/compile
@@ -9,7 +9,7 @@ scala:
   - 2.12.8
   - 2.13.0-RC1
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - SCALAJS_VERSION=0.6.27
   - SCALAJS_VERSION=1.0.0-M7


### PR DESCRIPTION
It seems that Travis no longer install `oraclejdk8` (then [build fails](https://travis-ci.org/scala-js/scala-js-dom/jobs/545496915#L165)) so let's use `openjdk8`.

[As of  2019-04-15, `xenial` is now default and recommended on Travis](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment), so let's move on instead of staying `trusty`. 
This PR explicitly specifies `xenial`, so it won't be updated to latest silently and break builds in future.

And [`sudo: false` is no longer be available](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) so let's drop it.