### PR TITLE
Implicit DOMTokenList to Seq (e.g. for Element.classList) support

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/package.scala
+++ b/src/main/scala/org/scalajs/dom/ext/package.scala
@@ -10,7 +10,7 @@ package object ext {
       extends EasySeq[Node](nodes.length, nodes.apply)
 
   implicit class PimpedDOMTokenList(nodes: DOMTokenList)
-	  extends EasySeq[String](nodes.length, nodes.apply)
+      extends EasySeq[String](nodes.length, nodes.apply)
 
   implicit class PimpedTouchList(nodes: TouchList)
       extends EasySeq[Touch](nodes.length, nodes.apply)

--- a/src/main/scala/org/scalajs/dom/ext/package.scala
+++ b/src/main/scala/org/scalajs/dom/ext/package.scala
@@ -9,6 +9,9 @@ package object ext {
   implicit class PimpedNodeList(nodes: NodeList)
       extends EasySeq[Node](nodes.length, nodes.apply)
 
+  implicit class PimpedDOMTokenList(nodes: DOMTokenList)
+	  extends EasySeq[String](nodes.length, nodes.apply)
+
   implicit class PimpedTouchList(nodes: TouchList)
       extends EasySeq[Touch](nodes.length, nodes.apply)
 


### PR DESCRIPTION
Probably it was accidentally forgotten and it will be convenient to have something like Element.classList.foreach or filter additionally to the others.
Don't you think?