### PR TITLE
Fix the return type of URLSearchParams.get

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/URL.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/URL.scala
@@ -119,7 +119,7 @@ class URLSearchParams
 
   def delete(name: String): Unit = js.native
 
-  def get(name: String): js.UndefOr[String] = js.native
+  def get(name: String): String = js.native
 
   def getAll(name: String): Sequence[String] = js.native
 


### PR DESCRIPTION
According to the documentation
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get#Return_value
URLSearchParams.get will return null but not undefined when the parameter is not found.