### PR TITLE
Add experimental Storage API support.

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/storage/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/storage/package.scala
@@ -1,0 +1,32 @@
+package org.scalajs.dom.experimental
+
+import org.scalajs.dom
+
+import scala.language.implicitConversions
+import scala.scalajs.js
+
+/**
+ * https://storage.spec.whatwg.org/
+ */
+package object storage {
+  implicit def toNavigatorStorage(navigator: dom.Navigator): NavigatorStorage =
+    navigator.asInstanceOf[NavigatorStorage]
+
+  @js.native
+  trait NavigatorStorage extends js.Object {
+    val storage: StorageManager = js.native
+  }
+
+  @js.native
+  trait StorageManager extends js.Any {
+    def persisted(): js.Promise[Boolean] = js.native
+    def persist(): js.Promise[Boolean] = js.native
+    def estimate(): js.Promise[StorageEstimate] = js.native
+  }
+
+  @js.native
+  trait StorageEstimate extends js.Any {
+    val usage: Double = js.native
+    val quota: Double = js.native
+  }
+}


### PR DESCRIPTION
Closes #377 

https://storage.spec.whatwg.org/

Chrome and Firefox have implemented
https://developer.mozilla.org/en-US/docs/Web/API/Storage_API#Browser_compatibility