### PR TITLE
Make the fields of RequestInit optional.

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -133,30 +133,31 @@ object RequestInit {
  * The underlying object is a dictionary. This trait is here to help encode
  * the types.
  */
+@js.native
 trait RequestInit extends js.Object {
   var method: js.UndefOr[HttpMethod]
 
-  var headers: js.UndefOr[HeadersInit]
+  var headers: js.UndefOr[HeadersInit] = js.undefined
 
   var body: js.UndefOr[BodyInit]
 
-  var referrer: js.UndefOr[String]
+  var referrer: js.UndefOr[String] = js.undefined
 
-  var referrerPolicy: js.UndefOr[ReferrerPolicy]
+  var referrerPolicy: js.UndefOr[ReferrerPolicy] = js.undefined
 
-  var mode: js.UndefOr[RequestMode]
+  var mode: js.UndefOr[RequestMode] = js.undefined
 
-  var credentials: js.UndefOr[RequestCredentials]
+  var credentials: js.UndefOr[RequestCredentials] = js.undefined
 
-  var cache: js.UndefOr[RequestCache]
+  var cache: js.UndefOr[RequestCache] = js.undefined
 
-  var redirect: js.UndefOr[RequestRedirect]
+  var redirect: js.UndefOr[RequestRedirect] = js.undefined
 
-  var integrity: js.UndefOr[String]
+  var integrity: js.UndefOr[String] = js.undefined
 
-  var keepalive: js.UndefOr[Boolean]
+  var keepalive: js.UndefOr[Boolean] = js.undefined
 
-  var signal: js.UndefOr[AbortSignal]
+  var signal: js.UndefOr[AbortSignal] = js.undefined
 
   /**
    * The whatwg spec section on [[https://fetch.spec.whatwg.org/#requestinit RequestInit dictionary]]
@@ -164,8 +165,9 @@ trait RequestInit extends js.Object {
    * In the detailed steps section for [[https://fetch.spec.whatwg.org/#dom-request the Request(input,init) constructor]]
    * it says even more clearly:
    * "If init's window member is present and it is not null, throw a TypeError."
+   * Therefore, this field is set to null and cannot be changed.
    */
-  var window: js.UndefOr[Null]
+  final var window: Null = null
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -133,13 +133,12 @@ object RequestInit {
  * The underlying object is a dictionary. This trait is here to help encode
  * the types.
  */
-@js.native
 trait RequestInit extends js.Object {
   var method: js.UndefOr[HttpMethod]
 
   var headers: js.UndefOr[HeadersInit] = js.undefined
 
-  var body: js.UndefOr[BodyInit]
+  var body: js.UndefOr[BodyInit] = js.undefined
 
   var referrer: js.UndefOr[String] = js.undefined
 
@@ -165,9 +164,10 @@ trait RequestInit extends js.Object {
    * In the detailed steps section for [[https://fetch.spec.whatwg.org/#dom-request the Request(input,init) constructor]]
    * it says even more clearly:
    * "If init's window member is present and it is not null, throw a TypeError."
-   * Therefore, this field is set to null and cannot be changed.
    */
-  final var window: Null = null
+  var window: Null
+
+  window = null
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -165,9 +165,7 @@ trait RequestInit extends js.Object {
    * it says even more clearly:
    * "If init's window member is present and it is not null, throw a TypeError."
    */
-  var window: Null
-
-  window = null
+  var window: js.UndefOr[Null] = js.undefined
 }
 
 /**

--- a/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Fetch.scala
@@ -134,7 +134,7 @@ object RequestInit {
  * the types.
  */
 trait RequestInit extends js.Object {
-  var method: js.UndefOr[HttpMethod]
+  var method: js.UndefOr[HttpMethod] = js.undefined
 
   var headers: js.UndefOr[HeadersInit] = js.undefined
 


### PR DESCRIPTION
This way, users do not have to recite every field when creating a `RequestInit`. Also, the spec says the `RequestInit` dictionary must contain a field `window` which is set to null. We might as well include this too as a final variable, since the spec shows omitting it should be a type error.

Prompted by gitter conversation here: https://gitter.im/scala-js/scala-js?at=5d80415105fd3716953afa47