### PR TITLE
Fix wrong parameter names in CollatorOptions

### DIFF
--- a/src/main/scala/org/scalajs/dom/experimental/intl/Intl.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/intl/Intl.scala
@@ -65,8 +65,8 @@ class NumberFormat(locales: String | js.Array[String],
 trait CollatorOptions extends js.Object {
   val localeMatcher: js.UndefOr[String]
   val usage: js.UndefOr[String]
-  val sensivity: js.UndefOr[String]
-  val ignore­Punctua­tion: js.UndefOr[Boolean]
+  val sensitivity: js.UndefOr[String]
+  val ignorePunctuation: js.UndefOr[Boolean]
   val numeric: js.UndefOr[Boolean]
   val caseFirst: js.UndefOr[String]
 }
@@ -94,7 +94,7 @@ object CollatorOptions {
    *                              Examples: a ≠ b, a ≠ á, a ≠ A.
    *                          The default is "variant" for usage "sort"; it's locale dependent for
    *                          usage "search".
-   * @param ignore­Punctua­tion Whether punctuation should be ignored. Possible values are true
+   * @param ignorePunctuation Whether punctuation should be ignored. Possible values are true
    *                          and false; the default is false.
    * @param numeric           Whether numeric collation should be used, such that "1" < "2" < "10".
    *                          Possible values are true and false; the default is false.
@@ -114,8 +114,8 @@ object CollatorOptions {
   def apply(
       localeMatcher: js.UndefOr[String] = js.undefined,
       usage: js.UndefOr[String] = js.undefined,
-      sensivity: js.UndefOr[String] = js.undefined,
-      ignore­Punctua­tion: js.UndefOr[Boolean] = js.undefined,
+      sensitivity: js.UndefOr[String] = js.undefined,
+      ignorePunctuation: js.UndefOr[Boolean] = js.undefined,
       numeric: js.UndefOr[Boolean] = js.undefined,
       caseFirst: js.UndefOr[String] = js.undefined
   ): CollatorOptions = {
@@ -123,8 +123,8 @@ object CollatorOptions {
       .literal(
           localeMatcher = localeMatcher,
           usage = usage,
-          sensivity = sensivity,
-          ignore­Punctua­tion = ignore­Punctua­tion,
+          sensitivity = sensitivity,
+          ignorePunctuation = ignorePunctuation,
           numeric = numeric,
           caseFirst = caseFirst
       )


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator
