### PR TITLE
Add Clipboard API

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -487,7 +487,22 @@ trait WindowTimers extends js.Object {
 @JSGlobal
 class Navigator
     extends NavigatorID with NavigatorOnLine with NavigatorContentUtils
-    with NavigatorGeolocation with NavigatorStorageUtils with NavigatorLanguage
+    with NavigatorGeolocation with NavigatorStorageUtils
+    with NavigatorLanguage {
+
+  /**
+   * The Clipboard API adds to the Navigator interface the read-only
+   * clipboard property, which returns the Clipboard object used to read
+   * and write the clipboard's contents. The Clipboard API can be used
+   * to implement cut, copy, and paste features within a web application.
+   *
+   * Use of the asynchronous clipboard read and write methods requires
+   * that the user grant the web site or app permission to access the
+   * clipboard. This permission must be obtained from the Permissions API
+   * using the "clipboard-read" and/or "clipboard-write" permissions.
+   */
+  def clipboard: Clipboard = js.native
+}
 
 @js.native
 trait NodeSelector extends js.Object {
@@ -7957,4 +7972,51 @@ object VisibilityState {
    * MDN
    */
   val unloaded = "unloaded".asInstanceOf[VisibilityState]
+}
+
+/**
+ * The Clipboard interface implements the Clipboard API, providing—if the user grants
+ * permission—both read and write access to the contents of the system clipboard.
+ * The Clipboard API can be used to implement cut, copy, and paste features within
+ * a web application.
+ *
+ * The system clipboard is exposed through the global Navigator.clipboard property
+ *
+ * Clipboard is based on the EventTarget interface, and includes its methods.
+ *
+ * MDN
+ */
+@js.native
+trait Clipboard extends EventTarget {
+
+  /**
+   * The read() method of the Clipboard interface requests a copy of the clipboard's
+   * contents, delivering the data to the returned Promise when the promise is
+   * resolved. Unlike readText(), the read() method can return arbitrary data,
+   * such as images.
+   *
+   * To read from the clipboard, you must first have the "clipboard-read" permission.
+   */
+  def read(): js.Promise[DataTransfer] = js.native
+
+  /**
+   * The readText() method returns a Promise which resolves with a copy of the
+   * textual contents of the system clipboard.
+   */
+  def readText(): js.Promise[String] = js.native
+
+  /**
+   * The write() method writes arbitrary data, such as images, to the clipboard.
+   * This can be used to implement cut and copy functionality.
+   *
+   * Before you can write to the clipboard, you need to use the Permissions API
+   * to get the "clipboard-write" permission.
+   */
+  def write(data: DataTransfer): js.Promise[Unit] = js.native
+
+  /**
+   * The writeText() method writes the specified text string to the system
+   * clipboard.
+   */
+  def writeText(newClipText: String): js.Promise[Unit] = js.native
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Clipboard

This PR adds `Clipboard` trait.
It's instance can be obtained via `Navigator.clipboard` property.