### PR TITLE
Fix CustomEventInit field name

### DIFF
--- a/src/main/scala/org/scalajs/dom/raw/lib.scala
+++ b/src/main/scala/org/scalajs/dom/raw/lib.scala
@@ -5677,7 +5677,7 @@ class StyleSheetList extends js.Object {
 }
 
 trait CustomEventInit extends EventInit {
-  var detailArg: js.UndefOr[Any] = js.undefined
+  var detail: js.UndefOr[Any] = js.undefined
 }
 
 /**


### PR DESCRIPTION
According to MDN https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent, `CustomEventInit` accept `"detail"` field, not `"detailArg"`.


