### PR TITLE
Add REST method PATCH for Ajax

### DIFF
--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -243,6 +243,12 @@ object Ajax {
     apply("PUT", url, data, timeout, headers, withCredentials, responseType)
   }
 
+  def patch(url: String, data: InputData = null, timeout: Int = 0,
+    headers: Map[String, String] = Map.empty,
+    withCredentials: Boolean = false, responseType: String = "") = {
+    apply("PATCH", url, data, timeout, headers, withCredentials, responseType)
+  }
+
   def delete(url: String, data: InputData = null, timeout: Int = 0,
       headers: Map[String, String] = Map.empty,
       withCredentials: Boolean = false, responseType: String = "") = {

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -244,8 +244,8 @@ object Ajax {
   }
 
   def patch(url: String, data: InputData = null, timeout: Int = 0,
-    headers: Map[String, String] = Map.empty,
-    withCredentials: Boolean = false, responseType: String = "") = {
+      headers: Map[String, String] = Map.empty,
+      withCredentials: Boolean = false, responseType: String = "") = {
     apply("PATCH", url, data, timeout, headers, withCredentials, responseType)
   }
 


### PR DESCRIPTION
For some reason Patch is absent in Ajax. THe following PR fixes this problem.