### PR TITLE
Add ghpages github action

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,28 @@
+
+name: Build and Deploy GhPages docs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: olafurpg/setup-scala@v5
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        run: sbt readme/run
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: readme/target/scalatex


### PR DESCRIPTION
Fixes #178  
As per [the docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#about-the-github_token-secret) the `secrets.GITHUB_TOKEN` is magically added by a Github Action.  
So it should *just work*™ .
I did try this with [one of my own projects](https://github.com/sake92/hepek/runs/1219699979?check_suite_focus=true) and it works fine! :)