### PR TITLE
WIP: initial attempt to update to scala 3.0.0-M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = project.in(file(".")).
 name := "Scala.js DOM"
 
 crossScalaVersions in ThisBuild := {
-  if (scalaJSVersion.startsWith("1.")) Seq("2.12.10", "2.11.12", "2.13.1")
+  if (scalaJSVersion.startsWith("1.")) Seq("2.12.10", "2.11.12", "2.13.1", "3.0.0-M3")
   else Seq("2.12.10", "2.11.12", "2.10.7", "2.13.1")
 }
 scalaVersion in ThisBuild := crossScalaVersions.value.head

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.6

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,8 +1,10 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.3.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.11")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
+
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")

--- a/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
+++ b/src/main/scala/org/scalajs/dom/crypto/Crypto.scala
@@ -930,10 +930,10 @@ object KeyFormat {
 trait RSAPublicKey extends js.Object {
 
   /* modulus, as a base64 URL encoded String */
-  @js.native
+  // @js.native
   def n: String = js.native
 
   /* exponent, as a base64 URL encoded String */
-  @js.native
+  // @js.native
   def e: String = js.native
 }

--- a/src/main/scala/org/scalajs/dom/ext/Extensions.scala
+++ b/src/main/scala/org/scalajs/dom/ext/Extensions.scala
@@ -213,7 +213,8 @@ object Ajax {
     implicit def byteBuffer2ajax(data: ByteBuffer): InputData = {
       if (data.hasTypedArray()) {
         // get relevant part of the underlying typed array
-        data.typedArray().subarray(data.position, data.limit)
+        val typedArray = data.typedArray()
+        typedArray.subarray(data.position, data.limit)
       } else {
         // fall back to copying the data
         val tempBuffer = ByteBuffer.allocateDirect(data.remaining)

--- a/src/main/scala/org/scalajs/dom/ext/package.scala
+++ b/src/main/scala/org/scalajs/dom/ext/package.scala
@@ -22,17 +22,17 @@ package object ext {
     def cast[T] = x.asInstanceOf[T]
   }
 
-  implicit def pimpAnimatedNumber(x: svg.AnimatedNumber) = x.baseVal
+  implicit def pimpAnimatedNumber(x: svg.AnimatedNumber): Double = x.baseVal //: runtime.Double
 
-  implicit def pimpRichAnimatedNumber(x: svg.AnimatedNumber) =
+  implicit def pimpRichAnimatedNumber(x: svg.AnimatedNumber): runtime.RichDouble =
     x.baseVal: runtime.RichDouble
 
-  implicit def pimpAnimatedLength(x: svg.AnimatedLength) = x.baseVal.value
+  implicit def pimpAnimatedLength(x: svg.AnimatedLength): Double = x.baseVal.value
 
-  implicit def pimpRichAnimatedLength(x: svg.AnimatedLength) =
+  implicit def pimpRichAnimatedLength(x: svg.AnimatedLength): runtime.RichDouble =
     x.baseVal.value: runtime.RichDouble
 
-  implicit def color2String(c: Color) = c.toString
+  implicit def color2String(c: Color): String = c.toString
   implicit class pimpedContext(val ctx: CanvasRenderingContext2D) {
     def prepCircle(x: Double, y: Double, r: Double) = {
       ctx.beginPath()


### PR DESCRIPTION
This is an attempt to upgrade the lib to scala 3.0.0-M3, unfortunately the compiler crash at building  a typed array, at this line

https://github.com/scala-js/scala-js-dom/compare/master...scalavision:upgrade-scala3-M3?expand=1#diff-314a459d5f91479dc5debdf12f163c51278abfcee6b3503ad31dea16d07a4f61R216

I will file a bug in either scala-js or dotty (depending on where it fits best) and point to this branch. I get this compiler output:

```scala
[error] -- Error: /../scala-js-dom/src/main/scala/org/scalajs/dom/ext/Extensions.scala:219:6 
[error] 219 |      tempBuffer.typedArray()
[error]     |      ^
[error]     |Recursion limit exceeded.
[error]     |Maybe there is an illegal cyclic reference?
[error]     |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
[error]     |A recurring operation is (inner to outer):

[error]     |  subtype scala.scalajs.js.typedarray.TypedArray[?, 
[error]     |  LazyRef(
[error]     |    scala.scalajs.js.typedarray.TypedArrayBufferOps[?
[error]     |       <: scala.scalajs.js.typedarray.TypedArray[?, ?]
[error]     |    ]#TypedArrayType
[error]     |  )
[error]     |] <:< scala.scalajs.js.typedarray.TypedArray[?, ?]
[error]     |  subtype Nothing <:< LazyRef(
[error]     |  scala.scalajs.js.typedarray.TypedArrayBufferOps[?
[error]     |     <: scala.scalajs.js.typedarray.TypedArray[?, ?]
[error]     |  ]#TypedArrayType
[error]     |)
[error]     |  subtype scala.scalajs.js.typedarray.TypedArray[?, 
[error]     |  LazyRef(
[error]     |    scala.scalajs.js.typedarray.TypedArrayBufferOps[?
[error]     |       <: scala.scalajs.js.typedarray.TypedArray[?, ?]
[error]     |    ]#TypedArrayType
[error]     |  )
[error]     |]
```
Increasing the stack doesn't help.

