### PR TITLE
Bump to 2.0.0-SNAPSHOT.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / crossScalaVersions := {
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 val commonSettings = Seq(
-  version := "1.2.0-SNAPSHOT",
+  version := "2.0.0-SNAPSHOT",
   organization := "org.scala-js",
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings")
 )


### PR DESCRIPTION
So that we can release v2.0.0 with the Scala 3 artifact.

Fixes #451.