### PR TITLE
Drop support for Scala.js 0.6.x.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.11.12", "2.12.10", "2.13.1"]
-        scalajsversion: ["1.x", "0.6.x"]
-        include:
-          - scalaversion: "2.10.7"
-            scalajsversion: "0.6.x"
-          - scalaversion: "3.0.1"
-            scalajsversion: "1.x"
-    env:
-      SCALAJS_VERSION: "${{ matrix.scalajsversion == '0.6.x' && '0.6.28' || '' }}"
+        scalaversion: ["2.11.12", "2.12.10", "2.13.1", "3.0.1"]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,7 @@ lazy val root = project.in(file(".")).
 
 name := "Scala.js DOM"
 
-ThisBuild / crossScalaVersions := {
-  if (scalaJSVersion.startsWith("1.")) Seq("2.12.10", "2.11.12", "2.13.1", "3.0.1")
-  else Seq("2.12.10", "2.11.12", "2.10.7", "2.13.1")
-}
+ThisBuild / crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1", "3.0.1")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 val commonSettings = Seq(
@@ -36,7 +33,6 @@ scalacOptions ++= {
 }
 
 def hasNewCollections(version: String): Boolean = {
-  !version.startsWith("2.10.") &&
   !version.startsWith("2.11.") &&
   !version.startsWith("2.12.")
 }


### PR DESCRIPTION
And therefore for Scala 2.10.x.