### PR TITLE
Upgrade to Scala 2.12.12 and 2.13.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.11.12", "2.12.10", "2.13.1", "3.0.1"]
+        scalaversion: ["2.11.12", "2.12.12", "2.13.4", "3.0.1"]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = project.in(file(".")).
 
 name := "Scala.js DOM"
 
-ThisBuild / crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1", "3.0.1")
+ThisBuild / crossScalaVersions := Seq("2.12.12", "2.11.12", "2.13.4", "3.0.1")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 val commonSettings = Seq(


### PR DESCRIPTION
Those are the reference versions for Scala.js 1.5.0, which we use, so they make the most sense. See
https://github.com/scala-js/scala-js/blob/v1.5.0/project/MultiScalaProject.scala#L80-L84