### PR TITLE
Enable MiMa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: sbt "++${{ matrix.scalaversion }}" example/compile
       - name: scalafmt
         run: sbt "++${{ matrix.scalaversion }}" scalafmtCheck
+      - name: mima
+        run: sbt "++${{ matrix.scalaversion }}" mimaReportBinaryIssues
   readme:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,13 @@ scalacOptions ++= {
   else Nil
 }
 
+import com.typesafe.tools.mima.core._
+mimaPreviousArtifacts := Set("org.scala-js" %%% "scalajs-dom" % "1.1.0")
+mimaBinaryIssueFilters ++= Seq(
+  // #427 SharedWorker onconnect has wrong type
+  ProblemFilters.exclude[Problem]("org.scalajs.dom.experimental.sharedworkers.SharedWorkerGlobalScope.onconnect*")
+)
+
 scmInfo := Some(ScmInfo(
     url("https://github.com/scala-js/scala-js-dom"),
     "scm:git:git@github.com:scala-js/scala-js-dom.git",

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,12 @@ scalacOptions ++= {
 }
 
 import com.typesafe.tools.mima.core._
-mimaPreviousArtifacts := Set("org.scala-js" %%% "scalajs-dom" % "1.1.0")
+mimaPreviousArtifacts := {
+  if (scalaVersion.value.startsWith("3"))
+    Set.empty
+  else
+    Set("org.scala-js" %%% "scalajs-dom" % "1.1.0")
+}
 mimaBinaryIssueFilters ++= Seq(
   // #427 SharedWorker onconnect has wrong type
   ProblemFilters.exclude[Problem]("org.scalajs.dom.experimental.sharedworkers.SharedWorkerGlobalScope.onconnect*")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.11")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")


### PR DESCRIPTION
This adds MiMa to the build, checking against 1.1.0. A bit silly for v2 of course, but helpful if we want to release another 1.x series.

The only problem found since 1.1.0 was introduced in https://github.com/scala-js/scala-js-dom/issues/427.

My 2 cents: since we are releasing a binary-incompatible v2 anyway, we should freeze binary compatibility in 1.x. Maybe we should make a series/1.x branch (possibly without #427), merge the approved/compatible PRs into there, and then forward merge them into main (aka series/2.x).