### PR TITLE
Add 2.10 hack to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
+      - name: Hacks for Scala 2.10
+        run: ./prepareForScala210.sh
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
I hope this works, it's a really sticky situation because `sbt-ci-release` wants to release all crosses at once.

Fixes #477