### PR TITLE
Fix #488 `HTMLMediaElement.play()` should return `Promise`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -4288,7 +4288,7 @@ raw/HTMLAudioElement[JC] var parentElement: HTMLElement
 raw/HTMLAudioElement[JC] def parentNode: Node
 raw/HTMLAudioElement[JC] def pause(): Unit
 raw/HTMLAudioElement[JC] def paused: Boolean
-raw/HTMLAudioElement[JC] def play(): Unit
+raw/HTMLAudioElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLAudioElement[JC] var playbackRate: Double
 raw/HTMLAudioElement[JC] def played: TimeRanges
 raw/HTMLAudioElement[JC] def prefix: String
@@ -9311,7 +9311,7 @@ raw/HTMLMediaElement[JC] var parentElement: HTMLElement
 raw/HTMLMediaElement[JC] def parentNode: Node
 raw/HTMLMediaElement[JC] def pause(): Unit
 raw/HTMLMediaElement[JC] def paused: Boolean
-raw/HTMLMediaElement[JC] def play(): Unit
+raw/HTMLMediaElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLMediaElement[JC] var playbackRate: Double
 raw/HTMLMediaElement[JC] def played: TimeRanges
 raw/HTMLMediaElement[JC] def prefix: String
@@ -14890,7 +14890,7 @@ raw/HTMLVideoElement[JC] var parentElement: HTMLElement
 raw/HTMLVideoElement[JC] def parentNode: Node
 raw/HTMLVideoElement[JC] def pause(): Unit
 raw/HTMLVideoElement[JC] def paused: Boolean
-raw/HTMLVideoElement[JC] def play(): Unit
+raw/HTMLVideoElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLVideoElement[JC] var playbackRate: Double
 raw/HTMLVideoElement[JC] def played: TimeRanges
 raw/HTMLVideoElement[JC] var poster: String

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -4288,7 +4288,7 @@ raw/HTMLAudioElement[JC] var parentElement: HTMLElement
 raw/HTMLAudioElement[JC] def parentNode: Node
 raw/HTMLAudioElement[JC] def pause(): Unit
 raw/HTMLAudioElement[JC] def paused: Boolean
-raw/HTMLAudioElement[JC] def play(): Unit
+raw/HTMLAudioElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLAudioElement[JC] var playbackRate: Double
 raw/HTMLAudioElement[JC] def played: TimeRanges
 raw/HTMLAudioElement[JC] def prefix: String
@@ -9311,7 +9311,7 @@ raw/HTMLMediaElement[JC] var parentElement: HTMLElement
 raw/HTMLMediaElement[JC] def parentNode: Node
 raw/HTMLMediaElement[JC] def pause(): Unit
 raw/HTMLMediaElement[JC] def paused: Boolean
-raw/HTMLMediaElement[JC] def play(): Unit
+raw/HTMLMediaElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLMediaElement[JC] var playbackRate: Double
 raw/HTMLMediaElement[JC] def played: TimeRanges
 raw/HTMLMediaElement[JC] def prefix: String
@@ -14890,7 +14890,7 @@ raw/HTMLVideoElement[JC] var parentElement: HTMLElement
 raw/HTMLVideoElement[JC] def parentNode: Node
 raw/HTMLVideoElement[JC] def pause(): Unit
 raw/HTMLVideoElement[JC] def paused: Boolean
-raw/HTMLVideoElement[JC] def play(): Unit
+raw/HTMLVideoElement[JC] def play(): js.UndefOr[js.Promise[Unit]]
 raw/HTMLVideoElement[JC] var playbackRate: Double
 raw/HTMLVideoElement[JC] def played: TimeRanges
 raw/HTMLVideoElement[JC] var poster: String

--- a/src/main/scala/org/scalajs/dom/raw/Html.scala
+++ b/src/main/scala/org/scalajs/dom/raw/Html.scala
@@ -3159,7 +3159,7 @@ abstract class HTMLMediaElement extends HTMLElement {
    *
    * MDN
    */
-  def play(): Unit = js.native
+  def play(): js.UndefOr[js.Promise[Unit]] = js.native
 
   /**
    * Begins loading the media content from the server.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play

The spec says:

> Browsers released before 2019 may not return a value from `play()`

So I made the return value `js.UndefOr[js.Promise[Unit]]`.