### PR TITLE
Fix return type of `FetchEvent.preloadResponse`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -984,7 +984,7 @@ experimental/serviceworkers/ExtendableMessageEventInit[JT] var scoped: js.UndefO
 experimental/serviceworkers/ExtendableMessageEventInit[JT] var source: js.UndefOr[Client | ServiceWorker | MessagePort]
 experimental/serviceworkers/FetchEvent[SC] def clientId: String
 experimental/serviceworkers/FetchEvent[SC] def isReload: Boolean
-experimental/serviceworkers/FetchEvent[SC] def preloadResponse: js.Promise[Response]
+experimental/serviceworkers/FetchEvent[SC] def preloadResponse: js.Promise[js.UndefOr[Response]]
 experimental/serviceworkers/FetchEvent[SC] def replacesClientId: String
 experimental/serviceworkers/FetchEvent[SC] def request: Request
 experimental/serviceworkers/FetchEvent[SC] def respondWith(promisedResponse: Response | js.Promise[Response]): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -984,7 +984,7 @@ experimental/serviceworkers/ExtendableMessageEventInit[JT] var scoped: js.UndefO
 experimental/serviceworkers/ExtendableMessageEventInit[JT] var source: js.UndefOr[Client | ServiceWorker | MessagePort]
 experimental/serviceworkers/FetchEvent[SC] def clientId: String
 experimental/serviceworkers/FetchEvent[SC] def isReload: Boolean
-experimental/serviceworkers/FetchEvent[SC] def preloadResponse: js.Promise[Response]
+experimental/serviceworkers/FetchEvent[SC] def preloadResponse: js.Promise[js.UndefOr[Response]]
 experimental/serviceworkers/FetchEvent[SC] def replacesClientId: String
 experimental/serviceworkers/FetchEvent[SC] def request: Request
 experimental/serviceworkers/FetchEvent[SC] def respondWith(promisedResponse: Response | js.Promise[Response]): Unit

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -111,7 +111,7 @@ class FetchEvent(typeArg: String, init: js.UndefOr[FetchEventInit])
    */
   def request: Request = js.native
 
-  def preloadResponse: js.Promise[Response] = js.native
+  def preloadResponse: js.Promise[js.UndefOr[Response]] = js.native
 
   def clientId: String = js.native
 


### PR DESCRIPTION
Cropped up in https://github.com/http4s/http4s/pull/5089.

https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/preloadResponse#value