### PR TITLE
Make reason for Readable/WritableStream cancel/abort optional

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -320,7 +320,7 @@ experimental/PointerLock.PointerLockDocument[JT] def pointerLockElement: Element
 experimental/PointerLock.PointerLockElement[JT] def requestPointerLock(): Unit
 experimental/PointerLock.PointerLockMouseEvent[JT] def movementX: Double
 experimental/PointerLock.PointerLockMouseEvent[JT] def movementY: Double
-experimental/ReadableStream[JT] def cancel(reason: String): js.Promise[Any]
+experimental/ReadableStream[JT] def cancel(reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit]
 experimental/ReadableStream[JT] def getReader(): ReadableStreamReader[T]
 experimental/ReadableStream[JT] def locked: Boolean
 experimental/ReadableStream[JT] def pipeThrough[U](pair: Any, options: Any = js.undefined): ReadableStream[U]
@@ -469,7 +469,7 @@ experimental/WriteableState[SO] val closing = "closing".asInstanceOf[WriteableSt
 experimental/WriteableState[SO] val errored = "errored".asInstanceOf[WriteableState]
 experimental/WriteableState[SO] val waiting = "waiting".asInstanceOf[WriteableState]
 experimental/WriteableState[SO] val writable = "writable".asInstanceOf[WriteableState]
-experimental/WriteableStream[JT] def abort(reason: Any): Unit
+experimental/WriteableStream[JT] def abort(reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit]
 experimental/WriteableStream[JT] def close(): js.Promise[WriteableStream[T]]
 experimental/WriteableStream[JT] val closed: js.Promise[WriteableStream[T]]
 experimental/WriteableStream[JT] val ready: js.Promise[WriteableStream[T]]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -320,7 +320,7 @@ experimental/PointerLock.PointerLockDocument[JT] def pointerLockElement: Element
 experimental/PointerLock.PointerLockElement[JT] def requestPointerLock(): Unit
 experimental/PointerLock.PointerLockMouseEvent[JT] def movementX: Double
 experimental/PointerLock.PointerLockMouseEvent[JT] def movementY: Double
-experimental/ReadableStream[JT] def cancel(reason: String): js.Promise[Any]
+experimental/ReadableStream[JT] def cancel(reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit]
 experimental/ReadableStream[JT] def getReader(): ReadableStreamReader[T]
 experimental/ReadableStream[JT] def locked: Boolean
 experimental/ReadableStream[JT] def pipeThrough[U](pair: Any, options: Any = js.undefined): ReadableStream[U]
@@ -469,7 +469,7 @@ experimental/WriteableState[SO] val closing = "closing".asInstanceOf[WriteableSt
 experimental/WriteableState[SO] val errored = "errored".asInstanceOf[WriteableState]
 experimental/WriteableState[SO] val waiting = "waiting".asInstanceOf[WriteableState]
 experimental/WriteableState[SO] val writable = "writable".asInstanceOf[WriteableState]
-experimental/WriteableStream[JT] def abort(reason: Any): Unit
+experimental/WriteableStream[JT] def abort(reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit]
 experimental/WriteableStream[JT] def close(): js.Promise[WriteableStream[T]]
 experimental/WriteableStream[JT] val closed: js.Promise[WriteableStream[T]]
 experimental/WriteableStream[JT] val ready: js.Promise[WriteableStream[T]]

--- a/src/main/scala/org/scalajs/dom/experimental/Stream.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/Stream.scala
@@ -87,9 +87,10 @@ trait WriteableStream[-T] extends js.Object {
    * abort mechanism of the underlying sink.
    * see [[https://streams.spec.whatwg.org/#ws-abort ¶4.2.4.4. abort(reason)]]
    *
-   * @param reason spec specifies Any (!?)
+   * @param reason
    */
-  def abort(reason: Any): Unit = js.native
+  def abort(
+      reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit] = js.native
 
   /**
    * The close method signals that the producer is done writing chunks to the
@@ -148,10 +149,11 @@ trait ReadableStream[+T] extends js.Object {
    * the stream by a consumer. The supplied reason argument will be given to
    * the underlying source, which may or may not use it.
    *
-   * @param reason the reason <- actually not what type this is
-   * @return a Promise, but not quite sure what it can contain
+   * @param reason the reason
+   * @return a Promise
    */
-  def cancel(reason: String): js.Promise[Any] = js.native
+  def cancel(
+      reason: js.UndefOr[Any] = js.undefined): js.Promise[Unit] = js.native
 
   /**
    * See [[https://streams.spec.whatwg.org/#rs-get-reader ¶3.2.4.3. getReader()]]


### PR DESCRIPTION
https://streams.spec.whatwg.org/#rs-class-definition
https://streams.spec.whatwg.org/#ws-class-definition

Useful for https://github.com/http4s/http4s/pull/5103.