### PR TITLE
Fix #504

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val root = project
 
 name := "Scala.js DOM"
 
+ThisBuild / version := "1.2.0"
 ThisBuild / crossScalaVersions := {
   if (scalaJSVersion.startsWith("1.")) Seq("2.12.10", "2.11.12", "2.13.1")
   else Seq("2.12.10", "2.11.12", "2.10.7", "2.13.1")


### PR DESCRIPTION
Our release GitHub Actions job performs the release for SJS 0.6 and 1.0 in parallel. This prevents each parallel processes from removing each other's deployment.
