### PR TITLE
Restore scalafix task to prePR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,11 @@ val prePR_nonCross = taskKey[Unit]("Performs all necessary work required before 
 ThisBuild / prePR_nonCross := Def.sequential(
   root / clean,
   root / Compile / scalafmt,
-  root / Compile / compile,
-  (root / Compile / scalafix).toTask(""),
+  Def.taskDyn {
+  if (scalaVersion.value.startsWith("2."))
+    (root / Compile / scalafix).toTask("")
+  else
+    Def.task(())
+  },
   example / Compile / compile,
 ).value

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ ThisBuild / prePR_nonCross := Def.sequential(
     if (scalaVersion.value.startsWith("2."))
       (root / Compile / scalafix).toTask("")
     else
-      (root / Compile / scalafix).toTask("")
+      (root / Compile / compile).toTask("")
   },
   example / Compile / compile,
 ).value

--- a/build.sbt
+++ b/build.sbt
@@ -145,5 +145,6 @@ ThisBuild / prePR_nonCross := Def.sequential(
   root / clean,
   root / Compile / scalafmt,
   root / Compile / compile,
+  (root / Compile / scalafix).toTask(""),
   example / Compile / compile,
 ).value

--- a/build.sbt
+++ b/build.sbt
@@ -145,10 +145,10 @@ ThisBuild / prePR_nonCross := Def.sequential(
   root / clean,
   root / Compile / scalafmt,
   Def.taskDyn {
-  if (scalaVersion.value.startsWith("2."))
-    (root / Compile / scalafix).toTask("")
-  else
-    Def.task(())
+    if (scalaVersion.value.startsWith("2."))
+      (root / Compile / scalafix).toTask("")
+    else
+      Def.task(())
   },
   example / Compile / compile,
 ).value

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ ThisBuild / prePR_nonCross := Def.sequential(
     if (scalaVersion.value.startsWith("2."))
       (root / Compile / scalafix).toTask("")
     else
-      Def.task(())
+      (root / Compile / scalafix).toTask("")
   },
   example / Compile / compile,
 ).value

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ ThisBuild / prePR_nonCross := Def.sequential(
     if (scalaVersion.value.startsWith("2."))
       (root / Compile / scalafix).toTask("")
     else
-      (root / Compile / compile).toTask("")
+      Def.task[Unit]((root / Compile / compile).value)
   },
   example / Compile / compile,
 ).value


### PR DESCRIPTION
Will fix #524.

Currently fails with:
> To use Scalafix on Scala 3 projects, you must unset `scalafixBinaryScalaVersion`. Rules such as ExplicitResultTypes requiring the project version to match the Scalafix version are unsupported for the moment.