### PR TITLE
Remove 1.x deprecatia

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -308,7 +308,6 @@ BiquadFilterNode[JT] def removeEventListener[T <: Event](`type`: String, listene
 BiquadFilterNode[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 BiquadFilterNode[JT] var `type`: String
 Blob[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
-Blob[JC] def close(): Unit  (@deprecated in 1.2.0)
 Blob[JC] def size: Double
 Blob[JC] def slice(start: Double?, end: Double?, contentType: String?): Blob
 Blob[JC] def stream(): ReadableStream[Uint8Array]
@@ -1597,7 +1596,6 @@ EventTarget[JC] def removeEventListener[T <: Event](`type`: String, listener: js
 External[JT]
 Fetch[JO] def fetch(info: RequestInfo, init: RequestInit = null): js.Promise[Response]
 File[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
-File[JC] def close(): Unit  (@deprecated in 1.2.0)
 File[JC] def name: String
 File[JC] def size: Double
 File[JC] def slice(start: Double?, end: Double?, contentType: String?): Blob
@@ -13145,7 +13143,6 @@ IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 IDBDatabase[JC] def transaction(storeNames: js.Any, mode: IDBTransactionMode?): IDBTransaction
 IDBDatabase[JC] def version: Int
-IDBEnvironment[JT] def indexedDB: IDBFactory  (@deprecated in 1.2.0)
 IDBFactory[JC] def cmp(first: js.Any, second: js.Any): Int
 IDBFactory[JC] def deleteDatabase(name: String): IDBOpenDBRequest
 IDBFactory[JC] def open(name: String): IDBOpenDBRequest
@@ -24030,22 +24027,6 @@ experimental/push/package[SO] implicit def pushServiceWorkerRegistration(swr: Se
 experimental/push/package.PushServiceWorkerGlobalScope[JT] var onpush: js.Function1[PushEvent, _]
 experimental/push/package.PushServiceWorkerGlobalScope[JT] var onpushsubscriptionchange: js.Function1[PushEvent, _]
 experimental/push/package.PushServiceWorkerRegistration[JT] val pushManager: PushManager
-experimental/serviceworkers/Cache[JC] def add(request: RequestInfo): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def addAll(requests: js.Array[RequestInfo]): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def delete(request: RequestInfo, options: js.UndefOr[CacheQueryOptions]?): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def keys(request: js.UndefOr[RequestInfo]?, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.Array[Request]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def `match`(request: RequestInfo, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.UndefOr[Response]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def matchAll(request: RequestInfo?, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.Array[Response]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def put(request: RequestInfo, response: Response): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var cacheName: String  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreMethod: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreSearch: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreVary: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def delete(cacheName: String): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def has(cacheName: String): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def keys(): js.Promise[js.Array[String]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def `match`(request: RequestInfo, options: CacheQueryOptions?): js.Promise[js.Any]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def open(cacheName: String): js.Promise[Cache]  (@deprecated in 1.2.0)
 experimental/serviceworkers/CanvasProxy[JT] def setContext(context: RenderingContext): Unit
 experimental/serviceworkers/Client[JT] def frameType: FrameType
 experimental/serviceworkers/Client[JT] def id: String
@@ -24708,7 +24689,6 @@ html[SO] def Media = HTMLMediaElement
 idb[SO] type Cursor = IDBCursor
 idb[SO] type CursorWithValue = IDBCursorWithValue
 idb[SO] type Database = IDBDatabase
-idb[SO] type Environment = IDBEnvironment  (@deprecated in 1.2.0)
 idb[SO] type Factory = IDBFactory
 idb[SO] type Index = IDBIndex
 idb[SO] type KeyRange = IDBKeyRange
@@ -24883,7 +24863,6 @@ raw[SO] type History = dom.History  (@deprecated in 2.0.0)
 raw[SO] type IDBCursor = dom.IDBCursor  (@deprecated in 2.0.0)
 raw[SO] type IDBCursorWithValue = dom.IDBCursorWithValue  (@deprecated in 2.0.0)
 raw[SO] type IDBDatabase = dom.IDBDatabase  (@deprecated in 2.0.0)
-raw[SO] type IDBEnvironment = dom.IDBEnvironment  (@deprecated in 2.0.0)
 raw[SO] type IDBFactory = dom.IDBFactory  (@deprecated in 2.0.0)
 raw[SO] type IDBIndex = dom.IDBIndex  (@deprecated in 2.0.0)
 raw[SO] type IDBKeyRange = dom.IDBKeyRange  (@deprecated in 2.0.0)

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -308,7 +308,6 @@ BiquadFilterNode[JT] def removeEventListener[T <: Event](`type`: String, listene
 BiquadFilterNode[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 BiquadFilterNode[JT] var `type`: String
 Blob[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
-Blob[JC] def close(): Unit  (@deprecated in 1.2.0)
 Blob[JC] def size: Double
 Blob[JC] def slice(start: Double?, end: Double?, contentType: String?): Blob
 Blob[JC] def stream(): ReadableStream[Uint8Array]
@@ -1597,7 +1596,6 @@ EventTarget[JC] def removeEventListener[T <: Event](`type`: String, listener: js
 External[JT]
 Fetch[JO] def fetch(info: RequestInfo, init: RequestInit = null): js.Promise[Response]
 File[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
-File[JC] def close(): Unit  (@deprecated in 1.2.0)
 File[JC] def name: String
 File[JC] def size: Double
 File[JC] def slice(start: Double?, end: Double?, contentType: String?): Blob
@@ -13145,7 +13143,6 @@ IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js
 IDBDatabase[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 IDBDatabase[JC] def transaction(storeNames: js.Any, mode: IDBTransactionMode?): IDBTransaction
 IDBDatabase[JC] def version: Int
-IDBEnvironment[JT] def indexedDB: IDBFactory  (@deprecated in 1.2.0)
 IDBFactory[JC] def cmp(first: js.Any, second: js.Any): Int
 IDBFactory[JC] def deleteDatabase(name: String): IDBOpenDBRequest
 IDBFactory[JC] def open(name: String): IDBOpenDBRequest
@@ -24030,22 +24027,6 @@ experimental/push/package[SO] implicit def pushServiceWorkerRegistration(swr: Se
 experimental/push/package.PushServiceWorkerGlobalScope[JT] var onpush: js.Function1[PushEvent, _]
 experimental/push/package.PushServiceWorkerGlobalScope[JT] var onpushsubscriptionchange: js.Function1[PushEvent, _]
 experimental/push/package.PushServiceWorkerRegistration[JT] val pushManager: PushManager
-experimental/serviceworkers/Cache[JC] def add(request: RequestInfo): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def addAll(requests: js.Array[RequestInfo]): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def delete(request: RequestInfo, options: js.UndefOr[CacheQueryOptions]?): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def keys(request: js.UndefOr[RequestInfo]?, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.Array[Request]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def `match`(request: RequestInfo, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.UndefOr[Response]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def matchAll(request: RequestInfo?, options: js.UndefOr[CacheQueryOptions]?): js.Promise[js.Array[Response]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/Cache[JC] def put(request: RequestInfo, response: Response): js.Promise[Unit]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var cacheName: String  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreMethod: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreSearch: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheQueryOptions[JT] var ignoreVary: Boolean  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def delete(cacheName: String): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def has(cacheName: String): js.Promise[Boolean]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def keys(): js.Promise[js.Array[String]]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def `match`(request: RequestInfo, options: CacheQueryOptions?): js.Promise[js.Any]  (@deprecated in 1.2.0)
-experimental/serviceworkers/CacheStorage[JT] def open(cacheName: String): js.Promise[Cache]  (@deprecated in 1.2.0)
 experimental/serviceworkers/CanvasProxy[JT] def setContext(context: RenderingContext): Unit
 experimental/serviceworkers/Client[JT] def frameType: FrameType
 experimental/serviceworkers/Client[JT] def id: String
@@ -24708,7 +24689,6 @@ html[SO] def Media = HTMLMediaElement
 idb[SO] type Cursor = IDBCursor
 idb[SO] type CursorWithValue = IDBCursorWithValue
 idb[SO] type Database = IDBDatabase
-idb[SO] type Environment = IDBEnvironment  (@deprecated in 1.2.0)
 idb[SO] type Factory = IDBFactory
 idb[SO] type Index = IDBIndex
 idb[SO] type KeyRange = IDBKeyRange
@@ -24883,7 +24863,6 @@ raw[SO] type History = dom.History  (@deprecated in 2.0.0)
 raw[SO] type IDBCursor = dom.IDBCursor  (@deprecated in 2.0.0)
 raw[SO] type IDBCursorWithValue = dom.IDBCursorWithValue  (@deprecated in 2.0.0)
 raw[SO] type IDBDatabase = dom.IDBDatabase  (@deprecated in 2.0.0)
-raw[SO] type IDBEnvironment = dom.IDBEnvironment  (@deprecated in 2.0.0)
 raw[SO] type IDBFactory = dom.IDBFactory  (@deprecated in 2.0.0)
 raw[SO] type IDBIndex = dom.IDBIndex  (@deprecated in 2.0.0)
 raw[SO] type IDBKeyRange = dom.IDBKeyRange  (@deprecated in 2.0.0)

--- a/src/main/scala/org/scalajs/dom/IDBTypes.scala
+++ b/src/main/scala/org/scalajs/dom/IDBTypes.scala
@@ -555,19 +555,3 @@ class IDBRequest extends EventTarget {
     */
   def result: js.Any = js.native
 }
-
-/** The IDBEvironment interface of the IndexedDB API provides asynchronous access to a client-side database. It is
-  * implemented by window and Worker objects.
-  */
-@deprecated(
-    "Removed. This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible. See https://developer.mozilla.org/en-US/docs/Web/API/IDBEnvironment",
-    "1.2.0")
-@js.native
-trait IDBEnvironment extends js.Object {
-
-  /** an IDBRequest object that communicates back to the requesting application through events. This design means that
-    * any number of requests can be active on any database at a time.
-    */
-  @deprecated("Use window.indexedDB", "1.2.0")
-  def indexedDB: IDBFactory = js.native
-}

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/ServiceWorkers.scala
@@ -480,25 +480,3 @@ trait ServiceWorkerGlobalScope extends WorkerGlobalScope {
 object ServiceWorkerGlobalScope extends js.Object {
   def self: ServiceWorkerGlobalScope = js.native
 }
-
-/** See [[https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/#cache ¶5.4 cache]] of ServiceWorker whatwg
-  * spec.
-  */
-@deprecated("Use org.scalajs.dom.experimental.cachestorage.Cache", "1.2.0")
-@js.native
-@JSGlobal
-abstract class Cache extends org.scalajs.dom.experimental.cachestorage.Cache
-
-/** See [[https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/#cache ¶5.4 cache]] of ServiceWorker whatwg
-  * spec.
-  */
-@deprecated("Use org.scalajs.dom.experimental.cachestorage.CacheQueryOptions", "1.2.0")
-@js.native
-trait CacheQueryOptions extends org.scalajs.dom.experimental.cachestorage.CacheQueryOptions
-
-/** See [[https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/#cache-storage ¶5.5 cache]] of ServiceWorker
-  * whatwg spec.
-  */
-@deprecated("Use org.scalajs.dom.experimental.cachestorage.CacheStorage", "1.2.0")
-@js.native
-trait CacheStorage extends org.scalajs.dom.experimental.cachestorage.CacheStorage

--- a/src/main/scala/org/scalajs/dom/idb.scala
+++ b/src/main/scala/org/scalajs/dom/idb.scala
@@ -17,9 +17,4 @@ object idb {
   type Transaction = IDBTransaction
   @inline def TransactionMode = IDBTransactionMode
   type VersionChangeEvent = IDBVersionChangeEvent
-
-  @deprecated(
-      "Removed. This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible. See https://developer.mozilla.org/en-US/docs/Web/API/IDBEnvironment",
-      "1.2.0")
-  type Environment = IDBEnvironment
 }

--- a/src/main/scala/org/scalajs/dom/lib.scala
+++ b/src/main/scala/org/scalajs/dom/lib.scala
@@ -5182,9 +5182,6 @@ object BlobPropertyBag {
 @JSGlobal
 class Blob(blobParts: js.Array[js.Any] = js.native, options: BlobPropertyBag = js.native) extends js.Object {
 
-  @deprecated("This method seems to have been added in error and not actually exist.", "1.2.0")
-  def close(): Unit = js.native
-
   /** The size, in bytes, of the data contained in the Blob object.
     */
   def size: Double = js.native

--- a/src/main/scala/org/scalajs/dom/raw.scala
+++ b/src/main/scala/org/scalajs/dom/raw.scala
@@ -487,9 +487,6 @@ object raw {
   @deprecated("use dom.IDBDatabase instead", "2.0.0")
   type IDBDatabase = dom.IDBDatabase
 
-  @deprecated("use dom.IDBEnvironment instead", "2.0.0")
-  type IDBEnvironment = dom.IDBEnvironment
-
   @deprecated("use dom.IDBFactory instead", "2.0.0")
   type IDBFactory = dom.IDBFactory
 


### PR DESCRIPTION
Not sure if it's too soon for this since 1.2.0 is still fresh. But if not now, then when? :)