### PR TITLE
Add `webcrypto`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -25954,6 +25954,7 @@ package[SO] @js.native @JSGlobal("console") val console: Console
 package[SO] lazy val css: DeprecatedCSSAliases.type  (@deprecated in 2.0.0)
 package[SO] @js.native @JSGlobal("document") val document: html.Document
 package[SO] @js.native @JSGlobal("fetch") def fetch(info: RequestInfo, init: RequestInit = null): js.Promise[Response]
+package[SO] @js.native @JSGlobal("crypto") val webcrypto: Crypto
 package[SO] @js.native @JSGlobal("window") val window: Window
 raw[SO] type AbstractWorker = dom.AbstractWorker  (@deprecated in 2.0.0)
 raw[SO] type AnalyserNode = dom.AnalyserNode  (@deprecated in 2.0.0)

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -25954,6 +25954,7 @@ package[SO] @js.native @JSGlobal("console") val console: Console
 package[SO] lazy val css: DeprecatedCSSAliases.type  (@deprecated in 2.0.0)
 package[SO] @js.native @JSGlobal("document") val document: html.Document
 package[SO] @js.native @JSGlobal("fetch") def fetch(info: RequestInfo, init: RequestInit = null): js.Promise[Response]
+package[SO] @js.native @JSGlobal("crypto") val webcrypto: Crypto
 package[SO] @js.native @JSGlobal("window") val window: Window
 raw[SO] type AbstractWorker = dom.AbstractWorker  (@deprecated in 2.0.0)
 raw[SO] type AnalyserNode = dom.AnalyserNode  (@deprecated in 2.0.0)

--- a/src/main/scala/org/scalajs/dom/package.scala
+++ b/src/main/scala/org/scalajs/dom/package.scala
@@ -104,4 +104,12 @@ package object dom {
     */
   type HashAlgorithmIdentifier = HashAlgorithm | String
 
+  /** This is the same as `crypto` in JS.
+    *
+    * To maintain backwards-source-compatibility with scala-js-dom v1, `crypto` in scala-js-dom is retained as a package
+    * object.
+    */
+  @js.native
+  @JSGlobal("crypto")
+  val webcrypto: Crypto = js.native
 }


### PR DESCRIPTION
Closes #597

I orginally thought the type would be js.UndefOr[Crypto] but according
to MDN, `crypto` is always available but not all of the methods are.
