### PR TITLE
Bring back `SharedWorkerGlobalScope` to deprecated package

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -25688,7 +25688,9 @@ experimental/serviceworkers/package[SO] type WindowClient = dom.WindowClient  (@
 experimental/serviceworkers/package[SO] @deprecated("use dom.ClientType instead", "2.0.0") val ClientType = dom.ClientType
 experimental/serviceworkers/package[SO] @deprecated("use dom.FrameType instead", "2.0.0") val FrameType = dom.FrameType
 experimental/serviceworkers/package[SO] @deprecated("use dom.ServiceWorkerState instead", "2.0.0") val ServiceWorkerState = dom.ServiceWorkerState
+experimental/serviceworkers/package[SO] def self: SharedWorkerGlobalScope
 experimental/serviceworkers/package[SO] implicit def toServiceWorkerNavigator(n: Navigator): ServiceWorkerNavigator  (@deprecated in 2.0.0)
+experimental/serviceworkers/package.SharedWorkerGlobalScope[JO] def self: SharedWorkerGlobalScope  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] type SharedWorker = dom.SharedWorker  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] type SharedWorkerGlobalScope = dom.SharedWorkerGlobalScope  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] @deprecated("use dom.SharedWorker instead", "2.0.0") val SharedWorker = dom.SharedWorker

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -25688,7 +25688,9 @@ experimental/serviceworkers/package[SO] type WindowClient = dom.WindowClient  (@
 experimental/serviceworkers/package[SO] @deprecated("use dom.ClientType instead", "2.0.0") val ClientType = dom.ClientType
 experimental/serviceworkers/package[SO] @deprecated("use dom.FrameType instead", "2.0.0") val FrameType = dom.FrameType
 experimental/serviceworkers/package[SO] @deprecated("use dom.ServiceWorkerState instead", "2.0.0") val ServiceWorkerState = dom.ServiceWorkerState
+experimental/serviceworkers/package[SO] def self: SharedWorkerGlobalScope
 experimental/serviceworkers/package[SO] implicit def toServiceWorkerNavigator(n: Navigator): ServiceWorkerNavigator  (@deprecated in 2.0.0)
+experimental/serviceworkers/package.SharedWorkerGlobalScope[JO] def self: SharedWorkerGlobalScope  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] type SharedWorker = dom.SharedWorker  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] type SharedWorkerGlobalScope = dom.SharedWorkerGlobalScope  (@deprecated in 2.0.0)
 experimental/sharedworkers/package[SO] @deprecated("use dom.SharedWorker instead", "2.0.0") val SharedWorker = dom.SharedWorker

--- a/src/main/scala/org/scalajs/dom/experimental/serviceworkers/package.scala
+++ b/src/main/scala/org/scalajs/dom/experimental/serviceworkers/package.scala
@@ -3,6 +3,8 @@ package experimental
 
 import org.scalajs.dom
 import scala.language.implicitConversions
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** Service Workers
   *
@@ -83,6 +85,13 @@ package object serviceworkers {
 
   @deprecated("use dom.ServiceWorkerGlobalScope instead", "2.0.0")
   type ServiceWorkerGlobalScope = dom.ServiceWorkerGlobalScope
+
+  @deprecated("use dom.ServiceWorkerGlobalScope instead", "2.0.0")
+  @js.native
+  @JSGlobalScope
+  object SharedWorkerGlobalScope extends js.Object {
+    def self: SharedWorkerGlobalScope = js.native
+  }
 
   @deprecated("use dom.ServiceWorkerMessageEventInit instead", "2.0.0")
   type ServiceWorkerMessageEventInit = dom.ServiceWorkerMessageEventInit


### PR DESCRIPTION
Fixes #604.