### PR TITLE
Explicitly set scalafmt dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = 3.0.6
+runner.dialect = scala213source3
 project.git = true
 style = Scala.js
 project.includeFilters = ["src/main/scala/org/scalajs/.*\\.scala"]


### PR DESCRIPTION
```
Default dialect is deprecated; use explicit: [Scala211,scala212,Scala212Source3,scala213,Scala213Source3,Sbt0137,Sbt1,scala3]
Also see https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects"
```

I chose `Scala213Source3` because that's what I've seen other projects do and I don't know better 😅 