### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual identity and orientation, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels.
+If you are being harassed, please contact us immediately so that we can support you.
+
+## Moderation
+
+Any questions, concerns, or moderation requests please contact a member of the project.
+
+- Arman Bilge: [twitter](https://twitter.com/armanbilge) | [email](mailto:arman@armanbilge.com)
+
+[Scala Code of Conduct]: https://www.scala-lang.org/conduct/


### PR DESCRIPTION
As scala-js-dom is under the scala-js org I assume the Scala Code of Conduct is already (implicitly) in place. This makes it explicit and also follows [GitHub recommendations](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).

I templated this from the code of conduct in the Typelevel repos I contribute to, e.g. [Cats Effect](https://github.com/typelevel/cats-effect/blob/series/3.x/CODE_OF_CONDUCT.md) and [http4s](https://github.com/http4s/http4s/blob/main/CODE_OF_CONDUCT.md).