### PR TITLE
Change ReadableStream#pipeTo to return js.Promise[Unit]

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15851,7 +15851,7 @@ ReadableStream[JT] def cancel(reason: js.UndefOr[Any]?): js.Promise[Unit]
 ReadableStream[JT] def getReader(): ReadableStreamReader[T]
 ReadableStream[JT] def locked: Boolean
 ReadableStream[JT] def pipeThrough[U](pair: Any, options: Any?): ReadableStream[U]
-ReadableStream[JT] def pipeTo(dest: WriteableStream[T], options: Any?): Unit
+ReadableStream[JT] def pipeTo(dest: WriteableStream[T], options: Any?): js.Promise[Unit]
 ReadableStream[JT] def tee(): js.Array[_ <: ReadableStream[T]]
 ReadableStream[SO] def apply[T](underlyingSource: js.UndefOr[ReadableStreamUnderlyingSource[T]]?, queuingStrategy: js.UndefOr[QueuingStrategy[T]]?): ReadableStream[T]
 ReadableStreamController[JC] def close(): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15851,7 +15851,7 @@ ReadableStream[JT] def cancel(reason: js.UndefOr[Any]?): js.Promise[Unit]
 ReadableStream[JT] def getReader(): ReadableStreamReader[T]
 ReadableStream[JT] def locked: Boolean
 ReadableStream[JT] def pipeThrough[U](pair: Any, options: Any?): ReadableStream[U]
-ReadableStream[JT] def pipeTo(dest: WriteableStream[T], options: Any?): Unit
+ReadableStream[JT] def pipeTo(dest: WriteableStream[T], options: Any?): js.Promise[Unit]
 ReadableStream[JT] def tee(): js.Array[_ <: ReadableStream[T]]
 ReadableStream[SO] def apply[T](underlyingSource: js.UndefOr[ReadableStreamUnderlyingSource[T]]?, queuingStrategy: js.UndefOr[QueuingStrategy[T]]?): ReadableStream[T]
 ReadableStreamController[JC] def close(): Unit

--- a/dom/src/main/scala/org/scalajs/dom/ReadableStream.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ReadableStream.scala
@@ -75,7 +75,7 @@ trait ReadableStream[+T] extends js.Object {
     *
     * //todo: determine the type of options
     */
-  def pipeTo(dest: WriteableStream[T], options: Any = js.native): Unit = js.native
+  def pipeTo(dest: WriteableStream[T], options: Any = js.native): js.Promise[Unit] = js.native
 
   /** See [[https://streams.spec.whatwg.org/#rs-tee ¶3.2.4.6. tee()]] of whatwg streams spec.
     *


### PR DESCRIPTION
Nice to meet you!

According to [the whatwg spec](https://streams.spec.whatwg.org/#rs-class-definition), `ReadableStream#pipeTo` should return a `Promise<undefined>`. This PR modifies the binding to return `js.Promise[Unit]` instead of a plain `Unit`.