### PR TITLE
Allow to easily override the chrome driver's path

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -93,6 +93,10 @@ object Build {
     .settings(
       Test / jsEnv := {
         System.setProperty("webdriver.chrome.silentOutput", "true")
+        // Allow setting up the chrome driver's absolute path from an environment variable
+        sys.env.get("CHROME_DRIVER").foreach { chromeDriver =>
+          System.setProperty("webdriver.chrome.driver", chromeDriver)
+        }
         val o = new ChromeOptions()
         o.setHeadless(true)
         o.addArguments("--allow-file-access-from-files")


### PR DESCRIPTION
The chrome driver's path can now be set through the `CHROME_DRIVER`
env variable, which is necessary for running tests.

Example:
- `CHROME_DRIVER=/bin/chromedriver sbt prePR`

This is an undocumented setting that is required while contributing changes.