### PR TITLE
Add type parameter for `MessageEvent#data`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -1297,7 +1297,7 @@ DedicatedWorkerGlobalScope[JT] def location: WorkerLocation
 DedicatedWorkerGlobalScope[JT] def navigator: WorkerNavigator
 DedicatedWorkerGlobalScope[JT] var onError: js.Function1[ErrorEvent, _]
 DedicatedWorkerGlobalScope[JT] var onlanguagechange: js.Function1[Event, _]
-DedicatedWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent, _]
+DedicatedWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 DedicatedWorkerGlobalScope[JT] var onoffline: js.Function1[Event, _]
 DedicatedWorkerGlobalScope[JT] var ononline: js.Function1[Event, _]
 DedicatedWorkerGlobalScope[JT] def origin: String
@@ -1828,7 +1828,7 @@ EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 EventSource[JC] def close(): Unit
 EventSource[JC] def dispatchEvent(evt: Event): Boolean
 EventSource[JC] var onerror: js.Function1[ErrorEvent, _]
-EventSource[JC] var onmessage: js.Function1[MessageEvent, _]
+EventSource[JC] var onmessage: js.Function1[MessageEvent[String], _]
 EventSource[JC] var onopen: js.Function1[Event, _]
 EventSource[JC] def readyState: Int
 EventSource[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -3205,7 +3205,7 @@ HTMLBodyElement[JC] var onload: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadeddata: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadedmetadata: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadstart: js.Function1[Event, _]
-HTMLBodyElement[JC] var onmessage: js.Function1[MessageEvent, _]
+HTMLBodyElement[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 HTMLBodyElement[JC] var onmousedown: js.Function1[MouseEvent, _]
 HTMLBodyElement[JC] var onmouseenter: js.Function1[MouseEvent, _]
 HTMLBodyElement[JC] var onmouseleave: js.Function1[MouseEvent, _]
@@ -14957,7 +14957,7 @@ MessageEvent[JC] def `type`: String
 MessageEventInit[JT] var bubbles: js.UndefOr[Boolean]
 MessageEventInit[JT] var cancelable: js.UndefOr[Boolean]
 MessageEventInit[JT] var composed: js.UndefOr[Boolean]
-MessageEventInit[JT] var data: js.UndefOr[Any]
+MessageEventInit[JT] var data: js.UndefOr[T]
 MessageEventInit[JT] var origin: js.UndefOr[String]
 MessageEventInit[JT] var scoped: js.UndefOr[Boolean]
 MessageEventInit[JT] var source: js.UndefOr[Window]
@@ -14965,7 +14965,7 @@ MessagePort[JT] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 MessagePort[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 MessagePort[JT] def close(): Unit
 MessagePort[JT] def dispatchEvent(evt: Event): Boolean
-MessagePort[JT] var onmessage: js.Function1[MessageEvent, _]
+MessagePort[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 MessagePort[JT] def postMessage(message: js.Any, transferList: js.UndefOr[js.Array[Transferable]]?): Unit
 MessagePort[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 MessagePort[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
@@ -15657,7 +15657,7 @@ RTCDataChannel[JT] val maxRetransmits: Double
 RTCDataChannel[JT] val negotiated: Boolean
 RTCDataChannel[JT] var onclose: js.Function1[Event, Any]
 RTCDataChannel[JT] var onerror: js.Function1[Event, Any]
-RTCDataChannel[JT] var onmessage: js.Function1[MessageEvent, Any]
+RTCDataChannel[JT] var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], Any]
 RTCDataChannel[JT] var onopen: js.Function1[Event, Any]
 RTCDataChannel[JT] val ordered: Boolean
 RTCDataChannel[JT] val protocol: String
@@ -23974,7 +23974,7 @@ ServiceWorkerContainer[JT] def dispatchEvent(evt: Event): Boolean
 ServiceWorkerContainer[JT] def getRegistration(scope: String?): js.Promise[js.UndefOr[ServiceWorkerRegistration]]
 ServiceWorkerContainer[JT] def getRegistrations(): js.Promise[js.Array[ServiceWorkerRegistration]]
 ServiceWorkerContainer[JT] var oncontrollerchange: js.Function1[Event, _]
-ServiceWorkerContainer[JT] var onmessage: js.Function1[MessageEvent, _]
+ServiceWorkerContainer[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 ServiceWorkerContainer[JT] def ready: js.Promise[ServiceWorkerRegistration]
 ServiceWorkerContainer[JT] def register(scriptURL: String, options: js.Object?): js.Promise[ServiceWorkerRegistration]
 ServiceWorkerContainer[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -24006,7 +24006,7 @@ ServiceWorkerGlobalScope[JT] var onactivate: js.Function1[ExtendableEvent, _]
 ServiceWorkerGlobalScope[JT] var onfetch: js.Function1[FetchEvent, _]
 ServiceWorkerGlobalScope[JT] var oninstall: js.Function1[ExtendableEvent, _]
 ServiceWorkerGlobalScope[JT] var onlanguagechange: js.Function1[Event, _]
-ServiceWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent, _]
+ServiceWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 ServiceWorkerGlobalScope[JT] var onoffline: js.Function1[Event, _]
 ServiceWorkerGlobalScope[JT] var ononline: js.Function1[Event, _]
 ServiceWorkerGlobalScope[JT] var onpush: js.Function1[PushEvent, _]
@@ -25033,7 +25033,7 @@ WebSocket[JC] def dispatchEvent(evt: Event): Boolean
 WebSocket[JC] def extensions: String
 WebSocket[JC] var onclose: js.Function1[CloseEvent, _]
 WebSocket[JC] var onerror: js.Function1[ErrorEvent, _]
-WebSocket[JC] var onmessage: js.Function1[MessageEvent, _]
+WebSocket[JC] var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], _]
 WebSocket[JC] var onopen: js.Function1[Event, _]
 WebSocket[JC] def readyState: Int
 WebSocket[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -25183,7 +25183,7 @@ Window[JC] var onload: js.Function1[Event, _]
 Window[JC] var onloadeddata: js.Function1[Event, _]
 Window[JC] var onloadedmetadata: js.Function1[Event, _]
 Window[JC] var onloadstart: js.Function1[Event, _]
-Window[JC] var onmessage: js.Function1[MessageEvent, _]
+Window[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 Window[JC] var onmousedown: js.Function1[MouseEvent, _]
 Window[JC] var onmousemove: js.Function1[MouseEvent, _]
 Window[JC] var onmouseout: js.Function1[MouseEvent, _]
@@ -25298,7 +25298,7 @@ Worker[JC] def addEventListener[T <: Event](`type`: String, listener: js.Functio
 Worker[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 Worker[JC] def dispatchEvent(evt: Event): Boolean
 Worker[JC] var onerror: js.Function1[ErrorEvent, _]
-Worker[JC] var onmessage: js.Function1[MessageEvent, _]
+Worker[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 Worker[JC] def postMessage(message: js.Any, transfer: js.UndefOr[js.Array[Transferable]]?): Unit
 Worker[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 Worker[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
@@ -26157,7 +26157,7 @@ raw[SO] type MediaQueryListListener = dom.MediaQueryListListener  (@deprecated i
 raw[SO] type MediaStreamAudioDestinationNode = dom.MediaStreamAudioDestinationNode  (@deprecated in 2.0.0)
 raw[SO] type MediaStreamAudioSourceNode = dom.MediaStreamAudioSourceNode  (@deprecated in 2.0.0)
 raw[SO] type MessageChannel = dom.MessageChannel  (@deprecated in 2.0.0)
-raw[SO] type MessageEvent = dom.MessageEvent  (@deprecated in 2.0.0)
+raw[SO] type MessageEvent = dom.MessageEvent[Any]  (@deprecated in 2.0.0)
 raw[SO] type MessagePort = dom.MessagePort  (@deprecated in 2.0.0)
 raw[SO] type ModifierKeyEvent = dom.ModifierKeyEvent  (@deprecated in 2.0.0)
 raw[SO] type MouseEvent = dom.MouseEvent  (@deprecated in 2.0.0)

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -14941,7 +14941,7 @@ MessageEvent[JC] def bubbles: Boolean
 MessageEvent[JC] def cancelBubble: Boolean
 MessageEvent[JC] def cancelable: Boolean
 MessageEvent[JC] def currentTarget: EventTarget
-MessageEvent[JC] def data: Any
+MessageEvent[JC] def data: T
 MessageEvent[JC] def defaultPrevented: Boolean
 MessageEvent[JC] def eventPhase: Int
 MessageEvent[JC] def isTrusted: Boolean

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -1297,7 +1297,7 @@ DedicatedWorkerGlobalScope[JT] def location: WorkerLocation
 DedicatedWorkerGlobalScope[JT] def navigator: WorkerNavigator
 DedicatedWorkerGlobalScope[JT] var onError: js.Function1[ErrorEvent, _]
 DedicatedWorkerGlobalScope[JT] var onlanguagechange: js.Function1[Event, _]
-DedicatedWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent, _]
+DedicatedWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 DedicatedWorkerGlobalScope[JT] var onoffline: js.Function1[Event, _]
 DedicatedWorkerGlobalScope[JT] var ononline: js.Function1[Event, _]
 DedicatedWorkerGlobalScope[JT] def origin: String
@@ -1828,7 +1828,7 @@ EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 EventSource[JC] def close(): Unit
 EventSource[JC] def dispatchEvent(evt: Event): Boolean
 EventSource[JC] var onerror: js.Function1[ErrorEvent, _]
-EventSource[JC] var onmessage: js.Function1[MessageEvent, _]
+EventSource[JC] var onmessage: js.Function1[MessageEvent[String], _]
 EventSource[JC] var onopen: js.Function1[Event, _]
 EventSource[JC] def readyState: Int
 EventSource[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -3205,7 +3205,7 @@ HTMLBodyElement[JC] var onload: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadeddata: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadedmetadata: js.Function1[Event, _]
 HTMLBodyElement[JC] var onloadstart: js.Function1[Event, _]
-HTMLBodyElement[JC] var onmessage: js.Function1[MessageEvent, _]
+HTMLBodyElement[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 HTMLBodyElement[JC] var onmousedown: js.Function1[MouseEvent, _]
 HTMLBodyElement[JC] var onmouseenter: js.Function1[MouseEvent, _]
 HTMLBodyElement[JC] var onmouseleave: js.Function1[MouseEvent, _]
@@ -14957,7 +14957,7 @@ MessageEvent[JC] def `type`: String
 MessageEventInit[JT] var bubbles: js.UndefOr[Boolean]
 MessageEventInit[JT] var cancelable: js.UndefOr[Boolean]
 MessageEventInit[JT] var composed: js.UndefOr[Boolean]
-MessageEventInit[JT] var data: js.UndefOr[Any]
+MessageEventInit[JT] var data: js.UndefOr[T]
 MessageEventInit[JT] var origin: js.UndefOr[String]
 MessageEventInit[JT] var scoped: js.UndefOr[Boolean]
 MessageEventInit[JT] var source: js.UndefOr[Window]
@@ -14965,7 +14965,7 @@ MessagePort[JT] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 MessagePort[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 MessagePort[JT] def close(): Unit
 MessagePort[JT] def dispatchEvent(evt: Event): Boolean
-MessagePort[JT] var onmessage: js.Function1[MessageEvent, _]
+MessagePort[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 MessagePort[JT] def postMessage(message: js.Any, transferList: js.UndefOr[js.Array[Transferable]]?): Unit
 MessagePort[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 MessagePort[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
@@ -15657,7 +15657,7 @@ RTCDataChannel[JT] val maxRetransmits: Double
 RTCDataChannel[JT] val negotiated: Boolean
 RTCDataChannel[JT] var onclose: js.Function1[Event, Any]
 RTCDataChannel[JT] var onerror: js.Function1[Event, Any]
-RTCDataChannel[JT] var onmessage: js.Function1[MessageEvent, Any]
+RTCDataChannel[JT] var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], Any]
 RTCDataChannel[JT] var onopen: js.Function1[Event, Any]
 RTCDataChannel[JT] val ordered: Boolean
 RTCDataChannel[JT] val protocol: String
@@ -23974,7 +23974,7 @@ ServiceWorkerContainer[JT] def dispatchEvent(evt: Event): Boolean
 ServiceWorkerContainer[JT] def getRegistration(scope: String?): js.Promise[js.UndefOr[ServiceWorkerRegistration]]
 ServiceWorkerContainer[JT] def getRegistrations(): js.Promise[js.Array[ServiceWorkerRegistration]]
 ServiceWorkerContainer[JT] var oncontrollerchange: js.Function1[Event, _]
-ServiceWorkerContainer[JT] var onmessage: js.Function1[MessageEvent, _]
+ServiceWorkerContainer[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 ServiceWorkerContainer[JT] def ready: js.Promise[ServiceWorkerRegistration]
 ServiceWorkerContainer[JT] def register(scriptURL: String, options: js.Object?): js.Promise[ServiceWorkerRegistration]
 ServiceWorkerContainer[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -24006,7 +24006,7 @@ ServiceWorkerGlobalScope[JT] var onactivate: js.Function1[ExtendableEvent, _]
 ServiceWorkerGlobalScope[JT] var onfetch: js.Function1[FetchEvent, _]
 ServiceWorkerGlobalScope[JT] var oninstall: js.Function1[ExtendableEvent, _]
 ServiceWorkerGlobalScope[JT] var onlanguagechange: js.Function1[Event, _]
-ServiceWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent, _]
+ServiceWorkerGlobalScope[JT] var onmessage: js.Function1[MessageEvent[Any], _]
 ServiceWorkerGlobalScope[JT] var onoffline: js.Function1[Event, _]
 ServiceWorkerGlobalScope[JT] var ononline: js.Function1[Event, _]
 ServiceWorkerGlobalScope[JT] var onpush: js.Function1[PushEvent, _]
@@ -25033,7 +25033,7 @@ WebSocket[JC] def dispatchEvent(evt: Event): Boolean
 WebSocket[JC] def extensions: String
 WebSocket[JC] var onclose: js.Function1[CloseEvent, _]
 WebSocket[JC] var onerror: js.Function1[ErrorEvent, _]
-WebSocket[JC] var onmessage: js.Function1[MessageEvent, _]
+WebSocket[JC] var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], _]
 WebSocket[JC] var onopen: js.Function1[Event, _]
 WebSocket[JC] def readyState: Int
 WebSocket[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -25183,7 +25183,7 @@ Window[JC] var onload: js.Function1[Event, _]
 Window[JC] var onloadeddata: js.Function1[Event, _]
 Window[JC] var onloadedmetadata: js.Function1[Event, _]
 Window[JC] var onloadstart: js.Function1[Event, _]
-Window[JC] var onmessage: js.Function1[MessageEvent, _]
+Window[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 Window[JC] var onmousedown: js.Function1[MouseEvent, _]
 Window[JC] var onmousemove: js.Function1[MouseEvent, _]
 Window[JC] var onmouseout: js.Function1[MouseEvent, _]
@@ -25298,7 +25298,7 @@ Worker[JC] def addEventListener[T <: Event](`type`: String, listener: js.Functio
 Worker[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 Worker[JC] def dispatchEvent(evt: Event): Boolean
 Worker[JC] var onerror: js.Function1[ErrorEvent, _]
-Worker[JC] var onmessage: js.Function1[MessageEvent, _]
+Worker[JC] var onmessage: js.Function1[MessageEvent[Any], _]
 Worker[JC] def postMessage(message: js.Any, transfer: js.UndefOr[js.Array[Transferable]]?): Unit
 Worker[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 Worker[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
@@ -26157,7 +26157,7 @@ raw[SO] type MediaQueryListListener = dom.MediaQueryListListener  (@deprecated i
 raw[SO] type MediaStreamAudioDestinationNode = dom.MediaStreamAudioDestinationNode  (@deprecated in 2.0.0)
 raw[SO] type MediaStreamAudioSourceNode = dom.MediaStreamAudioSourceNode  (@deprecated in 2.0.0)
 raw[SO] type MessageChannel = dom.MessageChannel  (@deprecated in 2.0.0)
-raw[SO] type MessageEvent = dom.MessageEvent  (@deprecated in 2.0.0)
+raw[SO] type MessageEvent = dom.MessageEvent[Any]  (@deprecated in 2.0.0)
 raw[SO] type MessagePort = dom.MessagePort  (@deprecated in 2.0.0)
 raw[SO] type ModifierKeyEvent = dom.ModifierKeyEvent  (@deprecated in 2.0.0)
 raw[SO] type MouseEvent = dom.MouseEvent  (@deprecated in 2.0.0)

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -14941,7 +14941,7 @@ MessageEvent[JC] def bubbles: Boolean
 MessageEvent[JC] def cancelBubble: Boolean
 MessageEvent[JC] def cancelable: Boolean
 MessageEvent[JC] def currentTarget: EventTarget
-MessageEvent[JC] def data: Any
+MessageEvent[JC] def data: T
 MessageEvent[JC] def defaultPrevented: Boolean
 MessageEvent[JC] def eventPhase: Int
 MessageEvent[JC] def isTrusted: Boolean

--- a/dom/src/main/scala/org/scalajs/dom/DedicatedWorkerGlobalScope.scala
+++ b/dom/src/main/scala/org/scalajs/dom/DedicatedWorkerGlobalScope.scala
@@ -14,7 +14,7 @@ trait DedicatedWorkerGlobalScope extends WorkerGlobalScope {
     * the message event occurs and bubbles through the Worker — i.e. when a message is sent to the worker using the
     * Worker.postMessage method.
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 
   /** The postMessage() method of the DedicatedWorkerGlobalScope interface sends a message to the main thread that
     * spawned it. This accepts a single parameter, which is the data to send to the worker. The data may be any value or

--- a/dom/src/main/scala/org/scalajs/dom/EventSource.scala
+++ b/dom/src/main/scala/org/scalajs/dom/EventSource.scala
@@ -37,7 +37,7 @@ class EventSource(URL: String, settings: js.Dynamic = null) extends EventTarget 
 
   var onopen: js.Function1[Event, _] = js.native
 
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[String], _] = js.native
 
   var onerror: js.Function1[ErrorEvent, _] = js.native
 

--- a/dom/src/main/scala/org/scalajs/dom/HTMLBodyElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLBodyElement.scala
@@ -21,7 +21,7 @@ abstract class HTMLBodyElement extends HTMLElement {
   var ononline: js.Function1[Event, _] = js.native
 
   /** Reflects the onmessage HTML attribute value for a function to call when the document receives a message. */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 
   /** Exposes the window.onerror event handler to call when the document fails to load properly. Note: This handler is
     * triggered when the event reaches the window, not the body element. Use addEventListener() to attach an event

--- a/dom/src/main/scala/org/scalajs/dom/MessageEvent.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MessageEvent.scala
@@ -23,7 +23,7 @@ class MessageEvent[+T](typeArg: String, init: js.UndefOr[MessageEventInit[T]]) e
     *
     * This can be of any data type, and will default to null if not specified.
     */
-  def data: Any = js.native
+  def data: T = js.native
 
   def ports: js.Any = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/MessageEvent.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MessageEvent.scala
@@ -14,7 +14,7 @@ import scala.scalajs.js.annotation._
   */
 @js.native
 @JSGlobal
-class MessageEvent(typeArg: String, init: js.UndefOr[MessageEventInit]) extends Event(typeArg, init) {
+class MessageEvent[+T](typeArg: String, init: js.UndefOr[MessageEventInit[T]]) extends Event(typeArg, init) {
   def source: Window = js.native
 
   def origin: String = js.native

--- a/dom/src/main/scala/org/scalajs/dom/MessageEventInit.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MessageEventInit.scala
@@ -8,8 +8,8 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 
-trait MessageEventInit extends EventInit {
+trait MessageEventInit[T] extends EventInit {
   var source: js.UndefOr[Window] = js.undefined
   var origin: js.UndefOr[String] = js.undefined
-  var data: js.UndefOr[Any] = js.undefined
+  var data: js.UndefOr[T] = js.undefined
 }

--- a/dom/src/main/scala/org/scalajs/dom/MessagePort.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MessagePort.scala
@@ -17,7 +17,7 @@ trait MessagePort extends EventTarget {
   /** An EventListener, called whenever an MessageEvent of type message is fired on the port — that is, when the port
     * receives a message.
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 
   /** Disconnects the port,so it is no longer active. This stops the flow of messages to that port. */
   def close(): Unit = js.native

--- a/dom/src/main/scala/org/scalajs/dom/RTCDataChannel.scala
+++ b/dom/src/main/scala/org/scalajs/dom/RTCDataChannel.scala
@@ -49,7 +49,7 @@ trait RTCDataChannel extends EventTarget {
   /** Is the event handler called when the message event is received. Such an event is sent when a message is available
     * on the data connection.
     */
-  var onmessage: js.Function1[MessageEvent, Any] = js.native
+  var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], Any] = js.native
 
   /** Returns a DOMString indicating the type of binary data transmitted by the connection. This should be either "blob"
     * if Blob objects are being used or "arraybuffer" if ArrayBuffer objects are being used. Initially it is set to

--- a/dom/src/main/scala/org/scalajs/dom/ServiceWorkerContainer.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ServiceWorkerContainer.scala
@@ -49,5 +49,5 @@ trait ServiceWorkerContainer extends EventTarget {
     * occurs — when incoming messages are received to the ServiceWorkerContainer object (e.g., via a
     * MessagePort.postMessage() call).
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ServiceWorkerGlobalScope.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ServiceWorkerGlobalScope.scala
@@ -44,7 +44,7 @@ trait ServiceWorkerGlobalScope extends WorkerGlobalScope {
     * use the MessagePort.postMessage method to send messages to service workers. The service worker can optionally send
     * a response back via the MessagePort exposed in event.data.port, corresponding to the controlled page.
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 
   /** Forces the waiting service worker to become the active service worker. This method can be used with
     * [[Clients.claim]] to ensure that updates to the underlying service worker take effect immediately for both the

--- a/dom/src/main/scala/org/scalajs/dom/WebSocket.scala
+++ b/dom/src/main/scala/org/scalajs/dom/WebSocket.scala
@@ -9,6 +9,7 @@ package org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.typedarray.ArrayBuffer
+import scala.scalajs.js.|
 
 /** The WebSocket object provides the API for creating and managing a WebSocket connection to a server, as well as for
   * sending and receiving data on the connection.
@@ -46,7 +47,7 @@ class WebSocket(var url: String = js.native, var protocol: String = js.native) e
   /** An event listener to be called when a message is received from the server. The listener receives a MessageEvent
     * named "message".
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[String | Blob | ArrayBuffer], _] = js.native
 
   /** An event listener to be called when the WebSocket connection's readyState changes to CLOSED. The listener receives
     * a CloseEvent named "close".

--- a/dom/src/main/scala/org/scalajs/dom/Window.scala
+++ b/dom/src/main/scala/org/scalajs/dom/Window.scala
@@ -198,7 +198,7 @@ class Window
 
   /** An event handler property for focus events on the window. */
   var onfocus: js.Function1[FocusEvent, _] = js.native
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
   var ontimeupdate: js.Function1[Event, _] = js.native
 
   /** An event handler for the resize event on the window. */

--- a/dom/src/main/scala/org/scalajs/dom/Worker.scala
+++ b/dom/src/main/scala/org/scalajs/dom/Worker.scala
@@ -19,7 +19,7 @@ class Worker(stringUrl: String) extends AbstractWorker {
     * occurs. These events are of type MessageEvent and will be called when the worker calls its own postMessage()
     * method: it is the way that a Worker has to give back information to the thread that created it.
     */
-  var onmessage: js.Function1[MessageEvent, _] = js.native
+  var onmessage: js.Function1[MessageEvent[Any], _] = js.native
 
   /** The postMessage() method of the Worker interface sends a message to the worker's inner scope. This accepts a
     * single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled

--- a/dom/src/main/scala/org/scalajs/dom/raw.scala
+++ b/dom/src/main/scala/org/scalajs/dom/raw.scala
@@ -567,7 +567,7 @@ object raw {
   type MessageChannel = dom.MessageChannel
 
   @deprecated("use dom.MessageEvent instead", "2.0.0")
-  type MessageEvent = dom.MessageEvent
+  type MessageEvent = dom.MessageEvent[Any]
 
   @deprecated("use dom.MessagePort instead", "2.0.0")
   type MessagePort = dom.MessagePort

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -153,10 +153,10 @@ object Websocket {
   @JSExport
   def main(in: html.Input,
            pre: html.Pre) = {
-    val echo = "wss://echo.websocket.org"
+    val echo = "wss://ws.postman-echo.com/raw"
     val socket = new dom.WebSocket(echo)
     socket.onmessage = {
-      (e: dom.MessageEvent) =>
+      (e: dom.MessageEvent[_]) =>
         pre.textContent +=
           e.data.toString
     }

--- a/tests-webworker/src/main/scala/org/scalajs/dom/tests/webworker/Client.scala
+++ b/tests-webworker/src/main/scala/org/scalajs/dom/tests/webworker/Client.scala
@@ -11,7 +11,7 @@ final class Client(worker: Worker) {
   private var preInit = new js.Array[Message]
   private var promises = new js.Array[Promise[String]]
 
-  worker.onmessage = (e: MessageEvent) => {
+  worker.onmessage = (e: MessageEvent[Any]) => {
     val m = e.data.asInstanceOf[Message]
     if (m._1 == ServerStarted) {
       preInit.foreach(worker.postMessage(_))

--- a/tests-webworker/src/main/scala/org/scalajs/dom/tests/webworker/Server.scala
+++ b/tests-webworker/src/main/scala/org/scalajs/dom/tests/webworker/Server.scala
@@ -9,7 +9,7 @@ object Server extends ServerResponses {
   def main(args: Array[String]): Unit = {
     val ww = DedicatedWorkerGlobalScope.self
 
-    ww.onmessage = (e: MessageEvent) => {
+    ww.onmessage = (e: MessageEvent[Any]) => {
       val msgIn = e.data.asInstanceOf[Message]
       val id = msgIn._1
       val cmdId = msgIn._2


### PR DESCRIPTION
So, I was motivated to do this because the lack of precision annoyed me when using the `WebSocket` APIs. But for the record I'm not totally convinced if it's a good trade-off in terms of usability vs correctness.

1. TypeScript uses a type parameter, but they never actually instantiate it anywhere.
2. In many cases `Any` is really as precise as you can be, anyway.
3. I couldn't really find solid docs/spec making guarantees about more precise types for `MessageEvent#data`. I did populate it where I could, based on my inference/understanding. But I could be totally wrong there 😆 