### PR TITLE
Add Façade Types to Support ResizeObserver

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15963,8 +15963,8 @@ RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
-ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
-ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserver[JC] def observe(target: Element, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def unobserve(target: Element): Unit
 ResizeObserverBoxOption[JT]
 ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption
 ResizeObserverBoxOption[SO] val `content-box`: ResizeObserverBoxOption
@@ -15973,7 +15973,7 @@ ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
 ResizeObserverEntry[JT] def target: Element
-ResizeObserverOptions[JT] var box: js.UndefOr[String]
+ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15965,12 +15965,15 @@ RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
 ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
 ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserverBoxOption[JT]
+ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption
+ResizeObserverBoxOption[SO] val `content-box`: ResizeObserverBoxOption
+ResizeObserverBoxOption[SO] val `device-pixel-content-box`: ResizeObserverBoxOption
 ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
 ResizeObserverEntry[JT] def target: Node
-ResizeObserverOptions[JT] var box: js.UndefOr[String]
-ResizeObserverOptions[SO] def apply(box: Option[String] = None): ResizeObserverOptions
+ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15963,7 +15963,8 @@ RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
-ResizeObserver[JC] def observe(target: Element, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def observe(target: Element): Unit
+ResizeObserver[JC] def observe(target: Element, options: ResizeObserverOptions): Unit
 ResizeObserver[JC] def unobserve(target: Element): Unit
 ResizeObserverBoxOption[JT]
 ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15972,8 +15972,8 @@ ResizeObserverBoxOption[SO] val `device-pixel-content-box`: ResizeObserverBoxOpt
 ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
-ResizeObserverEntry[JT] def target: Node
-ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
+ResizeObserverEntry[JT] def target: Element
+ResizeObserverOptions[JT] var box: js.UndefOr[String]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -1237,12 +1237,18 @@ DOMList[SO] def iterator: Iterator[T]
 DOMList[SO] def length: Int
 DOMList[SO] def next(): T
 DOMParser[JC] def parseFromString(string: String, mimeType: MIMEType): Document
-DOMRect[JC] var bottom: Double
-DOMRect[JC] var height: Double
-DOMRect[JC] var left: Double
-DOMRect[JC] var right: Double
-DOMRect[JC] var top: Double
-DOMRect[JC] var width: Double
+DOMRect[JC] def bottom: Double
+DOMRect[JC] def height: Double
+DOMRect[JC] def height_ = (height: Double): Unit
+DOMRect[JC] def left: Double
+DOMRect[JC] def right: Double
+DOMRect[JC] def top: Double
+DOMRect[JC] def width: Double
+DOMRect[JC] def width_ = (width: Double): Unit
+DOMRect[JC] def x: Double
+DOMRect[JC] def x_ = (x: Double): Unit
+DOMRect[JC] def y: Double
+DOMRect[JC] def y_ = (y: Double): Unit
 DOMRectList[JC] @JSBracketAccess def apply(index: Int): T
 DOMRectList[JC] def length: Int
 DOMRectReadOnly[JT] def bottom: Double

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -1245,6 +1245,14 @@ DOMRect[JC] var top: Double
 DOMRect[JC] var width: Double
 DOMRectList[JC] @JSBracketAccess def apply(index: Int): T
 DOMRectList[JC] def length: Int
+DOMRectReadOnly[JT] def bottom: Double
+DOMRectReadOnly[JT] def height: Double
+DOMRectReadOnly[JT] def left: Double
+DOMRectReadOnly[JT] def right: Double
+DOMRectReadOnly[JT] def top: Double
+DOMRectReadOnly[JT] def width: Double
+DOMRectReadOnly[JT] def x: Double
+DOMRectReadOnly[JT] def y: Double
 DOMSettableTokenList[JT] def add(token: String): Unit
 DOMSettableTokenList[JT] @JSBracketAccess def apply(index: Int): T
 DOMSettableTokenList[JT] def contains(token: String): Boolean
@@ -15948,6 +15956,17 @@ RequestType[SO] val script: RequestType
 RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
+ResizeObserver[JC] def disconnect(): Unit
+ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
+ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
+ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
+ResizeObserverEntry[JT] def target: Node
+ResizeObserverOptions[JT] var box: js.UndefOr[String]
+ResizeObserverOptions[SO] def apply(box: Option[String] = None): ResizeObserverOptions
+ResizeObserverSize[JT] def blockSize: Double
+ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Response[JC] def blob(): js.Promise[Blob]
 Response[JC] val body: ReadableStream[Uint8Array]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15963,8 +15963,8 @@ RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
-ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
-ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserver[JC] def observe(target: Element, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def unobserve(target: Element): Unit
 ResizeObserverBoxOption[JT]
 ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption
 ResizeObserverBoxOption[SO] val `content-box`: ResizeObserverBoxOption
@@ -15973,7 +15973,7 @@ ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
 ResizeObserverEntry[JT] def target: Element
-ResizeObserverOptions[JT] var box: js.UndefOr[String]
+ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15965,12 +15965,15 @@ RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
 ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
 ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserverBoxOption[JT]
+ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption
+ResizeObserverBoxOption[SO] val `content-box`: ResizeObserverBoxOption
+ResizeObserverBoxOption[SO] val `device-pixel-content-box`: ResizeObserverBoxOption
 ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
 ResizeObserverEntry[JT] def target: Node
-ResizeObserverOptions[JT] var box: js.UndefOr[String]
-ResizeObserverOptions[SO] def apply(box: Option[String] = None): ResizeObserverOptions
+ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15963,7 +15963,8 @@ RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
 ResizeObserver[JC] def disconnect(): Unit
-ResizeObserver[JC] def observe(target: Element, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def observe(target: Element): Unit
+ResizeObserver[JC] def observe(target: Element, options: ResizeObserverOptions): Unit
 ResizeObserver[JC] def unobserve(target: Element): Unit
 ResizeObserverBoxOption[JT]
 ResizeObserverBoxOption[SO] val `border-box`: ResizeObserverBoxOption

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15972,8 +15972,8 @@ ResizeObserverBoxOption[SO] val `device-pixel-content-box`: ResizeObserverBoxOpt
 ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
 ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
-ResizeObserverEntry[JT] def target: Node
-ResizeObserverOptions[JT] var box: js.UndefOr[ResizeObserverBoxOption]
+ResizeObserverEntry[JT] def target: Element
+ResizeObserverOptions[JT] var box: js.UndefOr[String]
 ResizeObserverSize[JT] def blockSize: Double
 ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -1237,12 +1237,18 @@ DOMList[SO] def iterator: Iterator[T]
 DOMList[SO] def length: Int
 DOMList[SO] def next(): T
 DOMParser[JC] def parseFromString(string: String, mimeType: MIMEType): Document
-DOMRect[JC] var bottom: Double
-DOMRect[JC] var height: Double
-DOMRect[JC] var left: Double
-DOMRect[JC] var right: Double
-DOMRect[JC] var top: Double
-DOMRect[JC] var width: Double
+DOMRect[JC] def bottom: Double
+DOMRect[JC] def height: Double
+DOMRect[JC] def height_ = (height: Double): Unit
+DOMRect[JC] def left: Double
+DOMRect[JC] def right: Double
+DOMRect[JC] def top: Double
+DOMRect[JC] def width: Double
+DOMRect[JC] def width_ = (width: Double): Unit
+DOMRect[JC] def x: Double
+DOMRect[JC] def x_ = (x: Double): Unit
+DOMRect[JC] def y: Double
+DOMRect[JC] def y_ = (y: Double): Unit
 DOMRectList[JC] @JSBracketAccess def apply(index: Int): T
 DOMRectList[JC] def length: Int
 DOMRectReadOnly[JT] def bottom: Double

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -1245,6 +1245,14 @@ DOMRect[JC] var top: Double
 DOMRect[JC] var width: Double
 DOMRectList[JC] @JSBracketAccess def apply(index: Int): T
 DOMRectList[JC] def length: Int
+DOMRectReadOnly[JT] def bottom: Double
+DOMRectReadOnly[JT] def height: Double
+DOMRectReadOnly[JT] def left: Double
+DOMRectReadOnly[JT] def right: Double
+DOMRectReadOnly[JT] def top: Double
+DOMRectReadOnly[JT] def width: Double
+DOMRectReadOnly[JT] def x: Double
+DOMRectReadOnly[JT] def y: Double
 DOMSettableTokenList[JT] def add(token: String): Unit
 DOMSettableTokenList[JT] @JSBracketAccess def apply(index: Int): T
 DOMSettableTokenList[JT] def contains(token: String): Boolean
@@ -15948,6 +15956,17 @@ RequestType[SO] val script: RequestType
 RequestType[SO] val style: RequestType
 RequestType[SO] val track: RequestType
 RequestType[SO] val video: RequestType
+ResizeObserver[JC] def disconnect(): Unit
+ResizeObserver[JC] def observe(target: Node, options: js.UndefOr[ResizeObserverOptions]?): Unit
+ResizeObserver[JC] def unobserve(target: Node): Unit
+ResizeObserverEntry[JT] def borderBoxSize: js.Array[ResizeObserverSize]
+ResizeObserverEntry[JT] def contentBoxSize: js.Array[ResizeObserverSize]
+ResizeObserverEntry[JT] def contentRect: DOMRectReadOnly
+ResizeObserverEntry[JT] def target: Node
+ResizeObserverOptions[JT] var box: js.UndefOr[String]
+ResizeObserverOptions[SO] def apply(box: Option[String] = None): ResizeObserverOptions
+ResizeObserverSize[JT] def blockSize: Double
+ResizeObserverSize[JT] def inlineSize: Double
 Response[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Response[JC] def blob(): js.Promise[Blob]
 Response[JC] val body: ReadableStream[Uint8Array]

--- a/dom/src/main/scala-2/org/scalajs/dom/ResizeObserverBoxOption.scala
+++ b/dom/src/main/scala-2/org/scalajs/dom/ResizeObserverBoxOption.scala
@@ -1,0 +1,13 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+/** ResizeObserverOptions [[https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe]] */
+@js.native
+sealed trait ResizeObserverBoxOption extends js.Any
+
+object ResizeObserverBoxOption {
+  val `content-box`: ResizeObserverBoxOption = "content-box".asInstanceOf[ResizeObserverBoxOption]
+  val `border-box`: ResizeObserverBoxOption = "border-box".asInstanceOf[ResizeObserverBoxOption]
+  val `device-pixel-content-box`: ResizeObserverBoxOption = "device-pixel-content-box".asInstanceOf[ResizeObserverBoxOption]
+}

--- a/dom/src/main/scala-3/org/scalajs/dom/ResizeObserverBoxOption.scala
+++ b/dom/src/main/scala-3/org/scalajs/dom/ResizeObserverBoxOption.scala
@@ -1,0 +1,12 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+/** ResizeObserverOptions [[https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe]] */
+opaque type ResizeObserverBoxOption <: String = String
+
+object ResizeObserverBoxOption {
+  val `content-box`: ResizeObserverBoxOption = "content-box"
+  val `border-box`: ResizeObserverBoxOption = "border-box"
+  val `device-pixel-content-box`: ResizeObserverBoxOption = "device-pixel-content-box"
+}

--- a/dom/src/main/scala/org/scalajs/dom/DOMRect.scala
+++ b/dom/src/main/scala/org/scalajs/dom/DOMRect.scala
@@ -9,10 +9,7 @@ package org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-/** A DOMRect describes the size and position of a rectangle.
-  *
-  * MDN
-  */
+/** A DOMRect describes the size and position of a rectangle. */
 @js.native
 @JSGlobal
 class DOMRect extends DOMRectReadOnly {

--- a/dom/src/main/scala/org/scalajs/dom/DOMRect.scala
+++ b/dom/src/main/scala/org/scalajs/dom/DOMRect.scala
@@ -9,13 +9,15 @@ package org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
+/** A DOMRect describes the size and position of a rectangle.
+  *
+  * MDN
+  */
 @js.native
 @JSGlobal
-class DOMRect extends js.Object {
-  var left: Double = js.native
-  var width: Double = js.native
-  var right: Double = js.native
-  var top: Double = js.native
-  var bottom: Double = js.native
-  var height: Double = js.native
+class DOMRect extends DOMRectReadOnly {
+  def width_=(width: Double): Unit = js.native
+  def height_=(height: Double): Unit = js.native
+  def x_=(x: Double): Unit = js.native
+  def y_=(y: Double): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/DOMRectReadOnly.scala
+++ b/dom/src/main/scala/org/scalajs/dom/DOMRectReadOnly.scala
@@ -1,0 +1,55 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait DOMRectReadOnly extends js.Object {
+
+  /** The x coordinate of the DOMRect's origin.
+    *
+    * MDN
+    */
+  def x: Double = js.native
+
+  /** The y coordinate of the DOMRect's origin.
+    *
+    * MDN
+    */
+  def y: Double = js.native
+
+  /** The width of the DOMRect.
+    *
+    * MDN
+    */
+  def width: Double = js.native
+
+  /** The height of the DOMRect.
+    *
+    * MDN
+    */
+  def height: Double = js.native
+
+  /** Returns the top coordinate value of the DOMRect (usually the same as y.)
+    *
+    * MDN
+    */
+  def top: Double = js.native
+
+  /** Returns the right coordinate value of the DOMRect (usually the same as x + width).
+    *
+    * MDN
+    */
+  def right: Double = js.native
+
+  /** Returns the bottom coordinate value of the DOMRect (usually the same as y + height)
+    *
+    * MDN
+    */
+  def bottom: Double = js.native
+
+  /** Returns the left coordinate value of the DOMRect (usually the same as x)
+    *
+    * MDN
+    */
+  def left: Double = js.native
+}

--- a/dom/src/main/scala/org/scalajs/dom/DOMRectReadOnly.scala
+++ b/dom/src/main/scala/org/scalajs/dom/DOMRectReadOnly.scala
@@ -5,51 +5,27 @@ import scala.scalajs.js
 @js.native
 trait DOMRectReadOnly extends js.Object {
 
-  /** The x coordinate of the DOMRect's origin.
-    *
-    * MDN
-    */
+  /** The x coordinate of the DOMRect's origin. */
   def x: Double = js.native
 
-  /** The y coordinate of the DOMRect's origin.
-    *
-    * MDN
-    */
+  /** The y coordinate of the DOMRect's origin. */
   def y: Double = js.native
 
-  /** The width of the DOMRect.
-    *
-    * MDN
-    */
+  /** The width of the DOMRect. */
   def width: Double = js.native
 
-  /** The height of the DOMRect.
-    *
-    * MDN
-    */
+  /** The height of the DOMRect. */
   def height: Double = js.native
 
-  /** Returns the top coordinate value of the DOMRect (usually the same as y.)
-    *
-    * MDN
-    */
+  /** Returns the top coordinate value of the DOMRect (usually the same as y.) */
   def top: Double = js.native
 
-  /** Returns the right coordinate value of the DOMRect (usually the same as x + width).
-    *
-    * MDN
-    */
+  /** Returns the right coordinate value of the DOMRect (usually the same as x + width). */
   def right: Double = js.native
 
-  /** Returns the bottom coordinate value of the DOMRect (usually the same as y + height)
-    *
-    * MDN
-    */
+  /** Returns the bottom coordinate value of the DOMRect (usually the same as y + height) */
   def bottom: Double = js.native
 
-  /** Returns the left coordinate value of the DOMRect (usually the same as x)
-    *
-    * MDN
-    */
+  /** Returns the left coordinate value of the DOMRect (usually the same as x) */
   def left: Double = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
@@ -1,0 +1,33 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** The ResizeObserver constructor creates a new ResizeObserver object, which can be used to report changes to the
+  * content or border box of an Element or the bounding box of an SVGElement - MDN
+  *
+  * @param callback
+  *   The function called whenever an observed resize occurs. - MDN
+  */
+@js.native
+@JSGlobal
+class ResizeObserver(callback: js.Function2[js.Array[ResizeObserverEntry], ResizeObserver, _]) extends js.Object {
+
+  /** Starts observing the specified Element or SVGElement.
+    *
+    * MDN
+    */
+  def observe(target: Node, options: js.UndefOr[ResizeObserverOptions] = js.native): Unit = js.native
+
+  /** Unobserves all observed Element or SVGElement targets.
+    *
+    * MDN
+    */
+  def disconnect(): Unit = js.native
+
+  /** Ends the observing of a specified Element or SVGElement.
+    *
+    * MDN
+    */
+  def unobserve(target: Node): Unit = js.native
+}

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
@@ -14,11 +14,11 @@ import scala.scalajs.js.annotation.JSGlobal
 class ResizeObserver(callback: js.Function2[js.Array[ResizeObserverEntry], ResizeObserver, _]) extends js.Object {
 
   /** Starts observing the specified Element or SVGElement. */
-  def observe(target: Node, options: js.UndefOr[ResizeObserverOptions] = js.native): Unit = js.native
+  def observe(target: Element, options: js.UndefOr[ResizeObserverOptions] = js.native): Unit = js.native
 
   /** Unobserves all observed Element or SVGElement targets. */
   def disconnect(): Unit = js.native
 
   /** Ends the observing of a specified Element or SVGElement. */
-  def unobserve(target: Node): Unit = js.native
+  def unobserve(target: Element): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
@@ -14,7 +14,8 @@ import scala.scalajs.js.annotation.JSGlobal
 class ResizeObserver(callback: js.Function2[js.Array[ResizeObserverEntry], ResizeObserver, _]) extends js.Object {
 
   /** Starts observing the specified Element or SVGElement. */
-  def observe(target: Element, options: js.UndefOr[ResizeObserverOptions] = js.native): Unit = js.native
+  def observe(target: Element): Unit = js.native
+  def observe(target: Element, options: ResizeObserverOptions): Unit = js.native
 
   /** Unobserves all observed Element or SVGElement targets. */
   def disconnect(): Unit = js.native

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserver.scala
@@ -4,30 +4,21 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
 
 /** The ResizeObserver constructor creates a new ResizeObserver object, which can be used to report changes to the
-  * content or border box of an Element or the bounding box of an SVGElement - MDN
+  * content or border box of an Element or the bounding box of an SVGElement
   *
   * @param callback
-  *   The function called whenever an observed resize occurs. - MDN
+  *   The function called whenever an observed resize occurs.
   */
 @js.native
 @JSGlobal
 class ResizeObserver(callback: js.Function2[js.Array[ResizeObserverEntry], ResizeObserver, _]) extends js.Object {
 
-  /** Starts observing the specified Element or SVGElement.
-    *
-    * MDN
-    */
+  /** Starts observing the specified Element or SVGElement. */
   def observe(target: Node, options: js.UndefOr[ResizeObserverOptions] = js.native): Unit = js.native
 
-  /** Unobserves all observed Element or SVGElement targets.
-    *
-    * MDN
-    */
+  /** Unobserves all observed Element or SVGElement targets. */
   def disconnect(): Unit = js.native
 
-  /** Ends the observing of a specified Element or SVGElement.
-    *
-    * MDN
-    */
+  /** Ends the observing of a specified Element or SVGElement. */
   def unobserve(target: Node): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
@@ -10,7 +10,7 @@ trait ResizeObserverEntry extends js.Object {
 
   /** A reference to the Element or SVGElement being observed */
   def target: Element = js.native
-  
+
   /** An array containing objects with the new border box size of the observed element. The array is necessary to
     * support elements that have multiple fragments, which occur in multi-column scenarios.
     */

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
@@ -1,0 +1,41 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+/** The ResizeObserverEntry interface represents the object passedto the ResizeObserver() constructor's callback
+  * function, which allows you to access the new dimensions of the Element or SVGElement being observed.
+  *
+  * MDN
+  */
+@js.native
+trait ResizeObserverEntry extends js.Object {
+
+  /** A reference to the Element or SVGElement being observed
+    *
+    * MDN
+    */
+  def target: Node = js.native
+
+  /** An array containing objects with the new border box size of the observed element. The array is necessary to
+    * support elements that have multiple fragments, which occur in multi-column scenarios.
+    *
+    * MDN
+    */
+  def borderBoxSize: js.Array[ResizeObserverSize] = js.native
+
+  /** An array containing objects with the new content box size of the observed element. The array is necessary to
+    * support elements that have multiple fragments, which occur in multi-column scenarios.
+    *
+    * MDN
+    */
+  def contentBoxSize: js.Array[ResizeObserverSize] = js.native
+
+  /** A [[DOMRectReadOnly]] object containing the new size of the observed element when the callback is run. Note that
+    * this is better supported than the above two properties, but it is left over from an earlier implementation of the
+    * Resize Observer API, is still included in the spec for web compat reasons, and may be deprecated in future
+    * versions.
+    *
+    * MDN
+    */
+  def contentRect: DOMRectReadOnly = js.native
+}

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverEntry.scala
@@ -4,29 +4,20 @@ import scala.scalajs.js
 
 /** The ResizeObserverEntry interface represents the object passedto the ResizeObserver() constructor's callback
   * function, which allows you to access the new dimensions of the Element or SVGElement being observed.
-  *
-  * MDN
   */
 @js.native
 trait ResizeObserverEntry extends js.Object {
 
-  /** A reference to the Element or SVGElement being observed
-    *
-    * MDN
-    */
+  /** A reference to the Element or SVGElement being observed */
   def target: Node = js.native
 
   /** An array containing objects with the new border box size of the observed element. The array is necessary to
     * support elements that have multiple fragments, which occur in multi-column scenarios.
-    *
-    * MDN
     */
   def borderBoxSize: js.Array[ResizeObserverSize] = js.native
 
   /** An array containing objects with the new content box size of the observed element. The array is necessary to
     * support elements that have multiple fragments, which occur in multi-column scenarios.
-    *
-    * MDN
     */
   def contentBoxSize: js.Array[ResizeObserverSize] = js.native
 
@@ -34,8 +25,6 @@ trait ResizeObserverEntry extends js.Object {
     * this is better supported than the above two properties, but it is left over from an earlier implementation of the
     * Resize Observer API, is still included in the spec for web compat reasons, and may be deprecated in future
     * versions.
-    *
-    * MDN
     */
   def contentRect: DOMRectReadOnly = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
@@ -6,16 +6,3 @@ import scala.scalajs.js
 trait ResizeObserverOptions extends js.Object {
   var box: js.UndefOr[String] = js.native
 }
-
-/** Factory for [[ResizeObserverOptions]] objects. */
-object ResizeObserverOptions {
-
-  /** Creates a new [[ResizeObserverOptions]] object with the given values. */
-  def apply(
-      box: Option[String] = None
-  ): ResizeObserverOptions = {
-    val res = js.Dynamic.asInstanceOf[ResizeObserverOptions]
-    box.foreach(res.box = _)
-    res
-  }
-}

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
@@ -1,0 +1,21 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait ResizeObserverOptions extends js.Object {
+  var box: js.UndefOr[String] = js.native
+}
+
+/** Factory for [[ResizeObserverOptions]] objects. */
+object ResizeObserverOptions {
+
+  /** Creates a new [[ResizeObserverOptions]] object with the given values. */
+  def apply(
+      box: Option[String] = None
+  ): ResizeObserverOptions = {
+    val res = js.Dynamic.asInstanceOf[ResizeObserverOptions]
+    box.foreach(res.box = _)
+    res
+  }
+}

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
@@ -4,5 +4,5 @@ import scala.scalajs.js
 
 @js.native
 trait ResizeObserverOptions extends js.Object {
-  var box: js.UndefOr[String] = js.native
+  var box: js.UndefOr[ResizeObserverBoxOption] = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverOptions.scala
@@ -3,5 +3,5 @@ package org.scalajs.dom
 import scala.scalajs.js
 
 trait ResizeObserverOptions extends js.Object {
-  var box: js.UndefOr[String] = js.undefined
+  var box: js.UndefOr[ResizeObserverBoxOption] = js.undefined
 }

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverSize.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverSize.scala
@@ -1,0 +1,23 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait ResizeObserverSize extends js.Object {
+
+  /** The length of the observed element's border box in the block dimension. For boxes with a horizontal writing-mode,
+    * this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or
+    * width.
+    *
+    * MDN
+    */
+  def blockSize: Double = js.native
+
+  /** The length of the observed element's border box in the inline dimension. For boxes with a horizontal writing-mode,
+    * this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or
+    * height.
+    *
+    * MDN
+    */
+  def inlineSize: Double = js.native
+}

--- a/dom/src/main/scala/org/scalajs/dom/ResizeObserverSize.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ResizeObserverSize.scala
@@ -8,16 +8,12 @@ trait ResizeObserverSize extends js.Object {
   /** The length of the observed element's border box in the block dimension. For boxes with a horizontal writing-mode,
     * this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or
     * width.
-    *
-    * MDN
     */
   def blockSize: Double = js.native
 
   /** The length of the observed element's border box in the inline dimension. For boxes with a horizontal writing-mode,
     * this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or
     * height.
-    *
-    * MDN
     */
   def inlineSize: Double = js.native
 }


### PR DESCRIPTION
Mozilla Docs : https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
Similar to [MutationObserver](https://github.com/scala-js/scala-js-dom/blob/main/dom/src/main/scala/org/scalajs/dom/MutationObserver.scala)

I wasn't sure about adding [ResizeObserverEntry.devicePixelContentBoxSize](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/devicePixelContentBoxSize), since as of now it isn't supported by Safari. I decided to leave out, but I would be happy to add it into this PR.

I also added [DOMRectReadOnly](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly), which seems a bit out of place in this PR but a few of the interfaces require that type. I'm also a bit concerned about adding it in this state due to the already implemented [DOMRect](https://github.com/scala-js/scala-js-dom/blob/main/dom/src/main/scala/org/scalajs/dom/DOMRect.scala). In the Mozilla docs it indicates that DOMRect extends the DOMRectReadOnly interface, but that doesn't really transfer well to Scala (vars vs defs). Looking for some guidance on approach here. 