### PR TITLE
Add report validity facade method

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -3492,6 +3492,7 @@ HTMLButtonElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLButtonElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLButtonElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLButtonElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLButtonElement[JC] def reportValidity(): Boolean
 HTMLButtonElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLButtonElement[JC] def requestPointerLock(): Unit
 HTMLButtonElement[JC] def scrollHeight: Int
@@ -5094,6 +5095,7 @@ HTMLFieldSetElement[JC] def removeEventListener[T <: Event](`type`: String, list
 HTMLFieldSetElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLFieldSetElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLFieldSetElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLFieldSetElement[JC] def reportValidity(): Boolean
 HTMLFieldSetElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLFieldSetElement[JC] def requestPointerLock(): Unit
 HTMLFieldSetElement[JC] def scrollHeight: Int
@@ -5313,6 +5315,7 @@ HTMLFormElement[JC] def removeEventListener[T <: Event](`type`: String, listener
 HTMLFormElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLFormElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLFormElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLFormElement[JC] def reportValidity(): Boolean
 HTMLFormElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLFormElement[JC] def requestPointerLock(): Unit
 HTMLFormElement[JC] def reset(): Unit
@@ -6745,6 +6748,7 @@ HTMLInputElement[JC] def removeEventListener[T <: Event](`type`: String, listene
 HTMLInputElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLInputElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLInputElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLInputElement[JC] def reportValidity(): Boolean
 HTMLInputElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLInputElement[JC] def requestPointerLock(): Unit
 HTMLInputElement[JC] var required: Boolean
@@ -9003,6 +9007,7 @@ HTMLObjectElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLObjectElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLObjectElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLObjectElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLObjectElement[JC] def reportValidity(): Boolean
 HTMLObjectElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLObjectElement[JC] def requestPointerLock(): Unit
 HTMLObjectElement[JC] def scrollHeight: Int
@@ -10827,6 +10832,7 @@ HTMLSelectElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLSelectElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLSelectElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLSelectElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLSelectElement[JC] def reportValidity(): Boolean
 HTMLSelectElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLSelectElement[JC] def requestPointerLock(): Unit
 HTMLSelectElement[JC] var required: Boolean
@@ -12857,6 +12863,7 @@ HTMLTextAreaElement[JC] def removeEventListener[T <: Event](`type`: String, list
 HTMLTextAreaElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLTextAreaElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLTextAreaElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLTextAreaElement[JC] def reportValidity(): Boolean
 HTMLTextAreaElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLTextAreaElement[JC] def requestPointerLock(): Unit
 HTMLTextAreaElement[JC] var required: Boolean

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -3492,6 +3492,7 @@ HTMLButtonElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLButtonElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLButtonElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLButtonElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLButtonElement[JC] def reportValidity(): Boolean
 HTMLButtonElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLButtonElement[JC] def requestPointerLock(): Unit
 HTMLButtonElement[JC] def scrollHeight: Int
@@ -5094,6 +5095,7 @@ HTMLFieldSetElement[JC] def removeEventListener[T <: Event](`type`: String, list
 HTMLFieldSetElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLFieldSetElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLFieldSetElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLFieldSetElement[JC] def reportValidity(): Boolean
 HTMLFieldSetElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLFieldSetElement[JC] def requestPointerLock(): Unit
 HTMLFieldSetElement[JC] def scrollHeight: Int
@@ -5313,6 +5315,7 @@ HTMLFormElement[JC] def removeEventListener[T <: Event](`type`: String, listener
 HTMLFormElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLFormElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLFormElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLFormElement[JC] def reportValidity(): Boolean
 HTMLFormElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLFormElement[JC] def requestPointerLock(): Unit
 HTMLFormElement[JC] def reset(): Unit
@@ -6745,6 +6748,7 @@ HTMLInputElement[JC] def removeEventListener[T <: Event](`type`: String, listene
 HTMLInputElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLInputElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLInputElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLInputElement[JC] def reportValidity(): Boolean
 HTMLInputElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLInputElement[JC] def requestPointerLock(): Unit
 HTMLInputElement[JC] var required: Boolean
@@ -9003,6 +9007,7 @@ HTMLObjectElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLObjectElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLObjectElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLObjectElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLObjectElement[JC] def reportValidity(): Boolean
 HTMLObjectElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLObjectElement[JC] def requestPointerLock(): Unit
 HTMLObjectElement[JC] def scrollHeight: Int
@@ -10827,6 +10832,7 @@ HTMLSelectElement[JC] def removeEventListener[T <: Event](`type`: String, listen
 HTMLSelectElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLSelectElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLSelectElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLSelectElement[JC] def reportValidity(): Boolean
 HTMLSelectElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLSelectElement[JC] def requestPointerLock(): Unit
 HTMLSelectElement[JC] var required: Boolean
@@ -12857,6 +12863,7 @@ HTMLTextAreaElement[JC] def removeEventListener[T <: Event](`type`: String, list
 HTMLTextAreaElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 HTMLTextAreaElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
 HTMLTextAreaElement[JC] def replaceChildren(nodes: Node | String*): Unit
+HTMLTextAreaElement[JC] def reportValidity(): Boolean
 HTMLTextAreaElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 HTMLTextAreaElement[JC] def requestPointerLock(): Unit
 HTMLTextAreaElement[JC] var required: Boolean

--- a/dom/src/main/scala/org/scalajs/dom/HTMLButtonElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLButtonElement.scala
@@ -76,4 +76,6 @@ abstract class HTMLButtonElement extends HTMLElement {
   def checkValidity(): Boolean = js.native
 
   def setCustomValidity(error: String): Unit = js.native
+
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLFieldSetElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLFieldSetElement.scala
@@ -44,4 +44,6 @@ abstract class HTMLFieldSetElement extends HTMLElement {
     * suffering from a custom validity error, and does not validate.
     */
   def setCustomValidity(error: String): Unit = js.native
+
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLFormElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLFormElement.scala
@@ -80,4 +80,10 @@ abstract class HTMLFormElement extends HTMLElement {
   var noValidate: Boolean = js.native
 
   def checkValidity(): Boolean = js.native
+
+  /** The reportValidity() method returns true if the element's child controls satisfy their validation constraints.
+    * When false is returned, cancelable invalid events are fired for each invalid child and validation problems are
+    * reported to the user.
+    */
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLInputElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLInputElement.scala
@@ -237,4 +237,10 @@ abstract class HTMLInputElement extends HTMLElement {
     * suffering from a custom validity error, and does not validate.
     */
   def setCustomValidity(error: String): Unit = js.native
+
+  /** The reportValidity() method performs the same validity checking steps as the checkValidity() method. If the value
+    * is invalid, this method also fires the invalid event on the element, and (if the event isn't canceled) reports the
+    * problem to the user.
+    */
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLObjectElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLObjectElement.scala
@@ -68,4 +68,6 @@ abstract class HTMLObjectElement extends HTMLElement with GetSVGDocument {
     * suffering from a custom validity error, and does not validate.
     */
   def setCustomValidity(error: String): Unit = js.native
+
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLSelectElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLSelectElement.scala
@@ -95,4 +95,6 @@ abstract class HTMLSelectElement extends HTMLElement {
   def checkValidity(): Boolean = js.native
 
   def setCustomValidity(error: String): Unit = js.native
+
+  def reportValidity(): Boolean = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/HTMLTextAreaElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/HTMLTextAreaElement.scala
@@ -109,4 +109,6 @@ abstract class HTMLTextAreaElement extends HTMLElement {
     * suffering from a custom validity error, and does not validate.
     */
   def setCustomValidity(error: String): Unit = js.native
+
+  def reportValidity(): Boolean = js.native
 }


### PR DESCRIPTION
`setCustomValidity`s error message is shown only when `reportValidity`
is called afterwards.
See https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setCustomValidity
for example.
