### PR TITLE
Add URL-based overloads for History

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -14484,8 +14484,10 @@ History[JC] def go(delta: Int): Unit
 History[JC] def length: Int
 History[JC] def pushState(statedata: js.Any, title: String): Unit
 History[JC] def pushState(statedata: js.Any, title: String, url: String): Unit
+History[JC] def pushState(statedata: js.Any, title: String, url: URL): Unit
 History[JC] def replaceState(statedata: js.Any, title: String): Unit
 History[JC] def replaceState(statedata: js.Any, title: String, url: String): Unit
+History[JC] def replaceState(statedata: js.Any, title: String, url: URL): Unit
 History[JC] def state: js.Any
 HkdfCtrParams[JT] val context: BufferSource
 HkdfCtrParams[JT] val hash: HashAlgorithmIdentifier

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -14484,8 +14484,10 @@ History[JC] def go(delta: Int): Unit
 History[JC] def length: Int
 History[JC] def pushState(statedata: js.Any, title: String): Unit
 History[JC] def pushState(statedata: js.Any, title: String, url: String): Unit
+History[JC] def pushState(statedata: js.Any, title: String, url: URL): Unit
 History[JC] def replaceState(statedata: js.Any, title: String): Unit
 History[JC] def replaceState(statedata: js.Any, title: String, url: String): Unit
+History[JC] def replaceState(statedata: js.Any, title: String, url: URL): Unit
 History[JC] def state: js.Any
 HkdfCtrParams[JT] val context: BufferSource
 HkdfCtrParams[JT] val hash: HashAlgorithmIdentifier

--- a/dom/src/main/scala/org/scalajs/dom/History.scala
+++ b/dom/src/main/scala/org/scalajs/dom/History.scala
@@ -50,6 +50,8 @@ class History extends js.Object {
 
   def replaceState(statedata: js.Any, title: String, url: String): Unit = js.native
 
+  def replaceState(statedata: js.Any, title: String, url: URL): Unit = js.native
+
   /** Updates the most recent entry on the history stack to have the specified data, title, and, if provided, URL. The
     * data is treated as opaque by the DOM; you may specify any JavaScript object that can be serialized.  Note that
     * Firefox currently ignores the title parameter; for more information, see manipulating the browser history. Note:
@@ -61,6 +63,8 @@ class History extends js.Object {
   def replaceState(statedata: js.Any, title: String): Unit = js.native
 
   def pushState(statedata: js.Any, title: String, url: String): Unit = js.native
+
+  def pushState(statedata: js.Any, title: String, url: URL): Unit = js.native
 
   /** Pushes the given data onto the session history stack with the specified title and, if provided, URL. The data is
     * treated as opaque by the DOM; you may specify any JavaScript object that can be serialized.  Note that Firefox


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
- https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
- https://github.com/microsoft/TypeScript/blob/1490037f178d222c11351cb8a91d1380d224f085/lib/lib.dom.d.ts#L8896-L8897