### PR TITLE
Updates MediaQueryList to extend EventTarget

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15401,7 +15401,7 @@ Location[JT] def reload(flag: Boolean?): Unit
 Location[JT] def replace(url: String): Unit
 Location[JT] var search: String
 MIMEType[JT]
-MIMEType[SO] val `application/xhtml+xml` = "application/xhtml+xml".asInstanceOf[MIMEType]
+MIMEType[SO] val `application/xhtml+xml` =  "application/xhtml+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
@@ -15450,10 +15450,15 @@ MediaList[JC] def item(index: Int): String
 MediaList[JC] def length: Int
 MediaList[JC] def mediaText: String
 MediaList[JC] @scala.scalajs.js.annotation.JSBracketAccess def update(index: Int, v: String): Unit
-MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.3.0)
+MediaQueryList[JT] def dispatchEvent(evt: Event): Boolean
 MediaQueryList[JT] def matches: Boolean
 MediaQueryList[JT] var media: String
-MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.3.0)
 MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit
 MediaSource[JC] def activeSourceBuffers: SourceBufferList
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -16111,7 +16116,7 @@ PermissionName[JT]
 PermissionName[SO] val geolocation: PermissionName
 PermissionName[SO] val midi: PermissionName
 PermissionName[SO] val notifications: PermissionName
-PermissionName[SO] val `persistent-storage` = "persistent-storage".asInstanceOf[PermissionName]
+PermissionName[SO] val `persistent-storage` =  "persistent-storage".asInstanceOf[PermissionName]
 PermissionName[SO] val push: PermissionName
 PermissionState[JT]
 PermissionState[SO] val denied: PermissionState
@@ -16497,9 +16502,9 @@ RTCSessionDescriptionInit[SO] def apply(`type`: js.UndefOr[RTCSdpType]?, sdp: js
 RTCSignalingState[JT]
 RTCSignalingState[SO] val closed: RTCSignalingState
 RTCSignalingState[SO] val `have-local-offer` = "have-local-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-local-pranswer` = "have-local-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-local-pranswer` =  "have-local-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val `have-remote-offer` = "have-remote-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-remote-pranswer` = "have-remote-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-remote-pranswer` =  "have-remote-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val stable: RTCSignalingState
 RTCStats[JT] val id: String
 RTCStats[JT] val timestamp: Double
@@ -16569,9 +16574,9 @@ ReadableStreamUnderlyingSource[JT] var `type`: js.UndefOr[ReadableStreamType]
 ReferrerPolicy[JT]
 ReferrerPolicy[SO] val empty: ReferrerPolicy
 ReferrerPolicy[SO] val `no-referrer` = "no-referrer".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `no-referrer-when-downgrade` = "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `no-referrer-when-downgrade` =  "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `origin-only` = "origin-only".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `origin-when-cross-origin` = "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `origin-when-cross-origin` =  "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `unsafe-url` = "unsafe-url".asInstanceOf[ReferrerPolicy]
 Request[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Request[JC] def blob(): js.Promise[Blob]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15401,7 +15401,7 @@ Location[JT] def reload(flag: Boolean?): Unit
 Location[JT] def replace(url: String): Unit
 Location[JT] var search: String
 MIMEType[JT]
-MIMEType[SO] val `application/xhtml+xml` =  "application/xhtml+xml".asInstanceOf[MIMEType]
+MIMEType[SO] val `application/xhtml+xml` = "application/xhtml+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
@@ -15450,15 +15450,10 @@ MediaList[JC] def item(index: Int): String
 MediaList[JC] def length: Int
 MediaList[JC] def mediaText: String
 MediaList[JC] @scala.scalajs.js.annotation.JSBracketAccess def update(index: Int, v: String): Unit
-MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
-MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.3.0)
-MediaQueryList[JT] def dispatchEvent(evt: Event): Boolean
+MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit
 MediaQueryList[JT] def matches: Boolean
 MediaQueryList[JT] var media: String
-MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
-MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
-MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.3.0)
+MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit
 MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit
 MediaSource[JC] def activeSourceBuffers: SourceBufferList
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
@@ -16116,7 +16111,7 @@ PermissionName[JT]
 PermissionName[SO] val geolocation: PermissionName
 PermissionName[SO] val midi: PermissionName
 PermissionName[SO] val notifications: PermissionName
-PermissionName[SO] val `persistent-storage` =  "persistent-storage".asInstanceOf[PermissionName]
+PermissionName[SO] val `persistent-storage` = "persistent-storage".asInstanceOf[PermissionName]
 PermissionName[SO] val push: PermissionName
 PermissionState[JT]
 PermissionState[SO] val denied: PermissionState
@@ -16502,9 +16497,9 @@ RTCSessionDescriptionInit[SO] def apply(`type`: js.UndefOr[RTCSdpType]?, sdp: js
 RTCSignalingState[JT]
 RTCSignalingState[SO] val closed: RTCSignalingState
 RTCSignalingState[SO] val `have-local-offer` = "have-local-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-local-pranswer` =  "have-local-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-local-pranswer` = "have-local-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val `have-remote-offer` = "have-remote-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-remote-pranswer` =  "have-remote-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-remote-pranswer` = "have-remote-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val stable: RTCSignalingState
 RTCStats[JT] val id: String
 RTCStats[JT] val timestamp: Double
@@ -16574,9 +16569,9 @@ ReadableStreamUnderlyingSource[JT] var `type`: js.UndefOr[ReadableStreamType]
 ReferrerPolicy[JT]
 ReferrerPolicy[SO] val empty: ReferrerPolicy
 ReferrerPolicy[SO] val `no-referrer` = "no-referrer".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `no-referrer-when-downgrade` =  "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `no-referrer-when-downgrade` = "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `origin-only` = "origin-only".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `origin-when-cross-origin` =  "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `origin-when-cross-origin` = "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `unsafe-url` = "unsafe-url".asInstanceOf[ReferrerPolicy]
 Request[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Request[JC] def blob(): js.Promise[Blob]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15450,11 +15450,16 @@ MediaList[JC] def item(index: Int): String
 MediaList[JC] def length: Int
 MediaList[JC] def mediaText: String
 MediaList[JC] @scala.scalajs.js.annotation.JSBracketAccess def update(index: Int, v: String): Unit
-MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.4.0)
+MediaQueryList[JT] def dispatchEvent(evt: Event): Boolean
 MediaQueryList[JT] def matches: Boolean
-MediaQueryList[JT] var media: String
-MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit
-MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit
+MediaQueryList[JT] def media: String
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.4.0)
+MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit  (@deprecated in 2.4.0)
 MediaSource[JC] def activeSourceBuffers: SourceBufferList
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15450,11 +15450,16 @@ MediaList[JC] def item(index: Int): String
 MediaList[JC] def length: Int
 MediaList[JC] def mediaText: String
 MediaList[JC] @scala.scalajs.js.annotation.JSBracketAccess def update(index: Int, v: String): Unit
-MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def addListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.4.0)
+MediaQueryList[JT] def dispatchEvent(evt: Event): Boolean
 MediaQueryList[JT] def matches: Boolean
-MediaQueryList[JT] var media: String
-MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit
-MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit
+MediaQueryList[JT] def media: String
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MediaQueryList[JT] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MediaQueryList[JT] def removeListener(listener: MediaQueryListListener): Unit  (@deprecated in 2.4.0)
+MediaQueryListListener[JT] def apply(mql: MediaQueryList): Unit  (@deprecated in 2.4.0)
 MediaSource[JC] def activeSourceBuffers: SourceBufferList
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
 MediaSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit

--- a/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
@@ -8,8 +8,8 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 
-/** A MediaQueryList object stores information on a media query applied to a document,
-  * with support for both immediate and event-driven matching against the state of the document.
+/** A MediaQueryList object stores information on a media query applied to a document, with support for both immediate
+  * and event-driven matching against the state of the document.
   */
 @js.native
 trait MediaQueryList extends EventTarget {
@@ -20,25 +20,24 @@ trait MediaQueryList extends EventTarget {
   /** A string representing a serialized media query. */
   var media: String = js.native
 
-  /** Adds to the MediaQueryList a callback which is invoked whenever the media query status—whether or
-    * not the document matches the media queries in the list—changes.
+  /** Adds to the MediaQueryList a callback which is invoked whenever the media query status—whether or not the document
+    * matches the media queries in the list—changes.
     *
-    * This method exists primarily for backward compatibility;
-    * if possible, you should instead use addEventListener() to watch for the change event.
+    * This method exists primarily for backward compatibility; if possible, you should instead use addEventListener() to
+    * watch for the change event.
     * @deprecated
     */
-  @deprecated("Use addEventListener() instead")
+  @deprecated("Use addEventListener() instead", "2.3.0")
   def addListener(listener: MediaQueryListListener): Unit = js.native
 
-  /** Removes the specified listener callback from the callbacks to be invoked when the MediaQueryList
-    * changes media query status, which happens any time the document switches between matching and
-    * not matching the media queries listed in the MediaQueryList.
+  /** Removes the specified listener callback from the callbacks to be invoked when the MediaQueryList changes media
+    * query status, which happens any time the document switches between matching and not matching the media queries
+    * listed in the MediaQueryList.
     *
-    * This method has been kept for backward compatibility;
-    * if possible, you should generally use removeEventListener() to remove change notification callbacks
-    * (which should have previously been added using addEventListener()).
+    * This method has been kept for backward compatibility; if possible, you should generally use removeEventListener()
+    * to remove change notification callbacks (which should have previously been added using addEventListener()).
     * @deprecated
     */
-  @deprecated("Use removeEventListener() instead")
+  @deprecated("Use removeEventListener() instead", "2.3.0")
   def removeListener(listener: MediaQueryListListener): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
@@ -18,7 +18,7 @@ trait MediaQueryList extends EventTarget {
   def matches: Boolean = js.native
 
   /** A string representing a serialized media query. */
-  var media: String = js.native
+  def media: String = js.native
 
   /** Adds to the MediaQueryList a callback which is invoked whenever the media query status—whether or not the document
     * matches the media queries in the list—changes.
@@ -27,7 +27,7 @@ trait MediaQueryList extends EventTarget {
     * watch for the change event.
     * @deprecated
     */
-  @deprecated("Use addEventListener() instead", "2.3.0")
+  @deprecated("Use addEventListener() instead", "2.4.0")
   def addListener(listener: MediaQueryListListener): Unit = js.native
 
   /** Removes the specified listener callback from the callbacks to be invoked when the MediaQueryList changes media
@@ -38,6 +38,6 @@ trait MediaQueryList extends EventTarget {
     * to remove change notification callbacks (which should have previously been added using addEventListener()).
     * @deprecated
     */
-  @deprecated("Use removeEventListener() instead", "2.3.0")
+  @deprecated("Use removeEventListener() instead", "2.4.0")
   def removeListener(listener: MediaQueryListListener): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MediaQueryList.scala
@@ -8,23 +8,37 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 
-/** A MediaQueryList object maintains a list of media queries on a document, and handles sending notifications to
-  * listeners when the media queries on the document change.
+/** A MediaQueryList object stores information on a media query applied to a document,
+  * with support for both immediate and event-driven matching against the state of the document.
   */
 @js.native
-trait MediaQueryList extends js.Object {
+trait MediaQueryList extends EventTarget {
 
-  /** true if the document currently matches the media query list; otherwise false. Read only. */
+  /** A boolean value that returns true if the document currently matches the media query list, or false if not. */
   def matches: Boolean = js.native
 
-  /** The serialized media query list */
+  /** A string representing a serialized media query. */
   var media: String = js.native
 
-  /** Adds a new listener to the media query list. If the specified listener is already in the list, this method has no
-    * effect.
+  /** Adds to the MediaQueryList a callback which is invoked whenever the media query status—whether or
+    * not the document matches the media queries in the list—changes.
+    *
+    * This method exists primarily for backward compatibility;
+    * if possible, you should instead use addEventListener() to watch for the change event.
+    * @deprecated
     */
+  @deprecated("Use addEventListener() instead")
   def addListener(listener: MediaQueryListListener): Unit = js.native
 
-  /** Removes a listener from the media query list. Does nothing if the specified listener isn't already in the list. */
+  /** Removes the specified listener callback from the callbacks to be invoked when the MediaQueryList
+    * changes media query status, which happens any time the document switches between matching and
+    * not matching the media queries listed in the MediaQueryList.
+    *
+    * This method has been kept for backward compatibility;
+    * if possible, you should generally use removeEventListener() to remove change notification callbacks
+    * (which should have previously been added using addEventListener()).
+    * @deprecated
+    */
+  @deprecated("Use removeEventListener() instead")
   def removeListener(listener: MediaQueryListListener): Unit = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/MediaQueryListListener.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MediaQueryListListener.scala
@@ -8,10 +8,8 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 
-/** A MediaQueryList object maintains a list of media queries on a document, and handles sending notifications to
-  * listeners when the media queries on the document change.
-  */
 @js.native
+@deprecated("See MediaQueryList for more info", "2.4.0")
 trait MediaQueryListListener extends js.Object {
   def apply(mql: MediaQueryList): Unit = js.native
 }


### PR DESCRIPTION
It would seem that MediaQueryList was outdated, so I updated it according to the MDN: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList

## Changes

The main difference is that now MediaQueryList extends EventTarget which allows for `addEventListener` method and others. Deprecated `addListener` and `removeListener` methods. ~~I hope that I got the version number for @deprecated right.~~

## Issue

I could not get the compiler to compile with `addListener` because it expected `MediaQueryListListener`. Don't know if this has ever worked for someone. I am very new to scala and maybe I don't know how it was supposed to work.

## Before

```scala
val prefersDark: MediaQueryList = window.matchMedia("(prefers-color-scheme: dark)")

prefersDark.addListener({ (e: MediaQueryList) =>
  println(e.matches)
})
```

would complain about function: Unit not being of type MediaQueryListListener.

## After

```scala
val prefersDark: MediaQueryList = window.matchMedia("(prefers-color-scheme: dark)")

prefersDark.addEventListener({ (e: MediaQueryList) =>
    println(e.matches)
})
```

should be good now.

* run `sbt prePR` ✔ (done)

```
Index.scalatex:43:6: type mismatch;
[error]  found   : scalatex.site.Section.Proxy
[error]  required: scalatags.Text.all.Frag
[error]     (which expands to)  scalatags.generic.Frag[scalatags.text.Builder,String]
[error] @sect{scala-js-dom}
[error]      ^
[error] one error found
[error] (readme / Compile / compileIncremental) Compilation failed
[error] Total time: 117 s (01:57), completed 31. kol 2022. 11:17:41
[IJ]root>
```

Not sure if this was my fault?

* commit changes to `api-reports` ❌ (what does this mean?)
