### PR TITLE
Remove stale todo

### DIFF
--- a/dom/src/main/scala/org/scalajs/dom/Body.scala
+++ b/dom/src/main/scala/org/scalajs/dom/Body.scala
@@ -22,9 +22,7 @@ trait Body extends js.Object {
   /** Takes a Response stream and reads it to completion. It returns a promise that resolves with a FormData object. */
   def formData(): js.Promise[FormData] = js.native
 
-  /** Takes a Response stream and reads it to completion. It returns a promise that resolves with a JSON object. //todo:
-    * define the JSON type, and return a Promise[JSON] as per spec
-    */
+  /** Takes a Response stream and reads it to completion. It returns a promise that resolves with a JSON object. */
   def json(): js.Promise[js.Any] = js.native
 
   /** Takes a Response stream and reads it to completion. It returns a promise that resolves with a USVString (text). */


### PR DESCRIPTION
The spec uses `js.Any` there anyway and I see no real compelling reason to change it. The "`JSON`" type is just a POJSO plain-old-javascript-object.

https://fetch.spec.whatwg.org/#body