### PR TITLE
Allow `MediaSource` to be passed in to `URL.createObjectURL`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -26181,7 +26181,7 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(blob: Blob): String
+URL[JO] def createObjectURL(obj: Blob | File | MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit
 URLSearchParams[JC] def delete(name: String): Unit

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -26181,7 +26181,7 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(obj: Blob): String
+URL[JO] def createObjectURL(blob: Blob): String
 URL[JO] def createObjectURL(src: MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -26181,7 +26181,8 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(obj: Blob | File | MediaSource): String
+URL[JO] def createObjectURL(obj: Blob): String
+URL[JO] def createObjectURL(src: MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit
 URLSearchParams[JC] def delete(name: String): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -26181,7 +26181,7 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(blob: Blob): String
+URL[JO] def createObjectURL(obj: Blob | File | MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit
 URLSearchParams[JC] def delete(name: String): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -26181,7 +26181,7 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(obj: Blob): String
+URL[JO] def createObjectURL(blob: Blob): String
 URL[JO] def createObjectURL(src: MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -26181,7 +26181,8 @@ URL[JC] var protocol: String
 URL[JC] var search: String
 URL[JC] var searchParams: URLSearchParams
 URL[JC] var username: String
-URL[JO] def createObjectURL(obj: Blob | File | MediaSource): String
+URL[JO] def createObjectURL(obj: Blob): String
+URL[JO] def createObjectURL(src: MediaSource): String
 URL[JO] def revokeObjectURL(url: String): Unit
 URLSearchParams[JC] def append(name: String, value: String): Unit
 URLSearchParams[JC] def delete(name: String): Unit

--- a/dom/src/main/scala/org/scalajs/dom/URL.scala
+++ b/dom/src/main/scala/org/scalajs/dom/URL.scala
@@ -2,7 +2,6 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
-import scala.scalajs.js.|
 
 /** The URL object provides static methods used for creating object URLs. */
 @js.native
@@ -19,7 +18,10 @@ object URL extends js.Object {
     * parameter. The URL lifetime is tied to the document in the window on which it was created. The new object URL
     * represents the specified File, Blob or MediaSource object.
     */
-  def createObjectURL(obj: Blob | File | MediaSource): String = js.native
+  def createObjectURL(obj: Blob): String = js.native
+
+  def createObjectURL(src: MediaSource): String = js.native
+
 }
 
 /** The URL() constructor returns a newly created URL object representing the URL defined by the parameters. */

--- a/dom/src/main/scala/org/scalajs/dom/URL.scala
+++ b/dom/src/main/scala/org/scalajs/dom/URL.scala
@@ -18,7 +18,7 @@ object URL extends js.Object {
     * parameter. The URL lifetime is tied to the document in the window on which it was created. The new object URL
     * represents the specified File, Blob or MediaSource object.
     */
-  def createObjectURL(obj: Blob): String = js.native
+  def createObjectURL(blob: Blob): String = js.native
 
   def createObjectURL(src: MediaSource): String = js.native
 

--- a/dom/src/main/scala/org/scalajs/dom/URL.scala
+++ b/dom/src/main/scala/org/scalajs/dom/URL.scala
@@ -2,6 +2,7 @@ package org.scalajs.dom
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+import scala.scalajs.js.|
 
 /** The URL object provides static methods used for creating object URLs. */
 @js.native
@@ -16,9 +17,9 @@ object URL extends js.Object {
 
   /** The URL.createObjectURL() static method creates a DOMString containing an URL representing the object given in
     * parameter. The URL lifetime is tied to the document in the window on which it was created. The new object URL
-    * represents the specified File object or Blob object.
+    * represents the specified File, Blob or MediaSource object.
     */
-  def createObjectURL(blob: Blob): String = js.native
+  def createObjectURL(obj: Blob | File | MediaSource): String = js.native
 }
 
 /** The URL() constructor returns a newly created URL object representing the URL defined by the parameters. */


### PR DESCRIPTION
See [here](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static#parameters).
