### PR TITLE
Add Navigator's ProtocolHandler methods

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16477,13 +16477,20 @@ Navigator[JC] def mediaDevices: MediaDevices
 Navigator[JC] def onLine: Boolean
 Navigator[JC] val permissions: Permissions
 Navigator[JC] def platform: String
+Navigator[JC] def registerProtocolHandler(scheme: String, url: String): Unit
+Navigator[JC] def registerProtocolHandler(scheme: String, url: URL): Unit
 Navigator[JC] def sendBeacon(url: String, data: BodyInit?): Boolean
 Navigator[JC] val serviceWorker: ServiceWorkerContainer
 Navigator[JC] def storage: StorageManager
+Navigator[JC] def unregisterProtocolHandler(scheme: String, url: String): Unit
+Navigator[JC] def unregisterProtocolHandler(scheme: String, url: URL): Unit
 Navigator[JC] def userAgent: String
 Navigator[JC] def vibrate(duration: Double): Boolean
 Navigator[JC] def vibrate(pattern: js.Array[Double]): Boolean
-NavigatorContentUtils[JT]
+NavigatorContentUtils[JT] def registerProtocolHandler(scheme: String, url: String): Unit
+NavigatorContentUtils[JT] def registerProtocolHandler(scheme: String, url: URL): Unit
+NavigatorContentUtils[JT] def unregisterProtocolHandler(scheme: String, url: String): Unit
+NavigatorContentUtils[JT] def unregisterProtocolHandler(scheme: String, url: URL): Unit
 NavigatorGeolocation[JT] def geolocation: Geolocation
 NavigatorID[JT] def appName: String
 NavigatorID[JT] def appVersion: String

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -16477,13 +16477,20 @@ Navigator[JC] def mediaDevices: MediaDevices
 Navigator[JC] def onLine: Boolean
 Navigator[JC] val permissions: Permissions
 Navigator[JC] def platform: String
+Navigator[JC] def registerProtocolHandler(scheme: String, url: String): Unit
+Navigator[JC] def registerProtocolHandler(scheme: String, url: URL): Unit
 Navigator[JC] def sendBeacon(url: String, data: BodyInit?): Boolean
 Navigator[JC] val serviceWorker: ServiceWorkerContainer
 Navigator[JC] def storage: StorageManager
+Navigator[JC] def unregisterProtocolHandler(scheme: String, url: String): Unit
+Navigator[JC] def unregisterProtocolHandler(scheme: String, url: URL): Unit
 Navigator[JC] def userAgent: String
 Navigator[JC] def vibrate(duration: Double): Boolean
 Navigator[JC] def vibrate(pattern: js.Array[Double]): Boolean
-NavigatorContentUtils[JT]
+NavigatorContentUtils[JT] def registerProtocolHandler(scheme: String, url: String): Unit
+NavigatorContentUtils[JT] def registerProtocolHandler(scheme: String, url: URL): Unit
+NavigatorContentUtils[JT] def unregisterProtocolHandler(scheme: String, url: String): Unit
+NavigatorContentUtils[JT] def unregisterProtocolHandler(scheme: String, url: URL): Unit
 NavigatorGeolocation[JT] def geolocation: Geolocation
 NavigatorID[JT] def appName: String
 NavigatorID[JT] def appVersion: String

--- a/dom/src/main/scala/org/scalajs/dom/NavigatorContentUtils.scala
+++ b/dom/src/main/scala/org/scalajs/dom/NavigatorContentUtils.scala
@@ -9,4 +9,66 @@ package org.scalajs.dom
 import scala.scalajs.js
 
 @js.native
-trait NavigatorContentUtils extends js.Object
+trait NavigatorContentUtils extends js.Object {
+
+  /** The Navigator method registerProtocolHandler() lets websites register their ability to open or handle particular
+    * URL schemes (aka protocols).
+    *
+    * For example, this API lets webmail sites open mailto: URLs, or VoIP sites open tel: URLs.
+    *
+    * @see
+    *   https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler
+    *
+    * @param scheme
+    *   A string containing the permitted scheme for the protocol that the site wishes to handle. For example, you can
+    *   register to handle SMS text message links by passing the "sms" scheme.
+    * @param url
+    *   A string containing the URL of the handler. This URL must include %s, as a placeholder that will be replaced
+    *   with the escaped URL to be handled.
+    * @return
+    *   undefined
+    *
+    * @throws DOMException.SECURITY_ERR
+    *   The user agent blocked the registration. This might happen if:
+    *   - The registered scheme (protocol) is invalid, such as a scheme the browser handles itself (https:, about:,
+    *     etc.)
+    *   - The handler URL's origin does not match the origin of the page calling this API.
+    *   - The browser requires that this function is called from a secure context.
+    *   - The browser requires that the handler's URL be over HTTPS.
+    *
+    * @throws DOMException.SYNTAX_ERR
+    *   The %s placeholder is missing from the handler URL
+    */
+  def registerProtocolHandler(scheme: String, url: String): Unit = js.native
+  def registerProtocolHandler(scheme: String, url: URL): Unit = js.native
+
+  /** The Navigator method unregisterProtocolHandler() removes a protocol handler for a given URL scheme.
+    *
+    * This method is the inverse of registerProtocolHandler().
+    *
+    * @see
+    *   https://developer.mozilla.org/en-US/docs/Web/API/Navigator/unregisterProtocolHandler
+    *
+    * @param scheme
+    *   A string containing the permitted scheme in the protocol handler that will be unregistered. For example, you can
+    *   unregister the handler for SMS text message links by passing the "sms" scheme.
+    * @param url
+    *   A string containing the URL of the handler. This URL should match the one that was used to register the handler
+    *   (e.g. it must include %s).
+    * @return
+    *   undefined
+    *
+    * @throws DOMException.SECURITY_ERR
+    *   The user agent blocked unregistration. This might happen if:
+    *   - The registered scheme (protocol) is invalid, such as a scheme the browser handles itself (https:, about:,
+    *     etc.)
+    *   - The handler URL's origin does not match the origin of the page calling this API.
+    *   - The browser requires that this function is called from a secure context.
+    *   - The browser requires that the handler's URL be over HTTPS.
+    *
+    * @throws DOMException.SYNTAX_ERR
+    *   The %s placeholder is missing from the handler URL
+    */
+  def unregisterProtocolHandler(scheme: String, url: String): Unit = js.native
+  def unregisterProtocolHandler(scheme: String, url: URL): Unit = js.native
+}


### PR DESCRIPTION
Add to Navigator the two protocol handler methods:
- registerProtocolHandler - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler
- unregisterProtocolHandler - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/unregisterProtocolHandler
