### PR TITLE
Revert "Update sbt to 1.9.6"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.9.4


### PR DESCRIPTION
Somehow this broke our `prePR` command 🤔 