### PR TITLE
Fix type of `ImageData#data`

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -15465,7 +15465,7 @@ ImageBitmap[JT] def width: Double
 ImageCapture[JC] def grabFrame(): js.Promise[ImageBitmap]
 ImageCapture[JC] def takePhoto(): js.Promise[Blob]
 ImageCapture[JC] val track: MediaStreamTrack
-ImageData[JC] def data: js.Array[Int]
+ImageData[JC] def data: js.typedarray.Uint8ClampedArray
 ImageData[JC] def height: Int
 ImageData[JC] def width: Int
 InputEvent[JC] def bubbles: Boolean

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -15465,7 +15465,7 @@ ImageBitmap[JT] def width: Double
 ImageCapture[JC] def grabFrame(): js.Promise[ImageBitmap]
 ImageCapture[JC] def takePhoto(): js.Promise[Blob]
 ImageCapture[JC] val track: MediaStreamTrack
-ImageData[JC] def data: js.Array[Int]
+ImageData[JC] def data: js.typedarray.Uint8ClampedArray
 ImageData[JC] def height: Int
 ImageData[JC] def width: Int
 InputEvent[JC] def bubbles: Boolean

--- a/dom/src/main/scala/org/scalajs/dom/ImageData.scala
+++ b/dom/src/main/scala/org/scalajs/dom/ImageData.scala
@@ -23,7 +23,7 @@ class ImageData extends js.Object {
   /** Is a Uint8ClampedArray representing a one-dimensional array containing the data in the RGBA order, with integer
     * values between 0 and 255 (included).
     */
-  def data: js.Array[Int] = js.native
+  def data: js.typedarray.Uint8ClampedArray = js.native
 
   /** Is an unsigned long representing the actual height, in pixels, of the ImageData. */
   def height: Int = js.native


### PR DESCRIPTION
Fixes https://github.com/scala-js/scala-js-dom/issues/807.

https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data