### PR TITLE
fix: `NDEFReadingEventInit.serialNumber` returns a string

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16689,7 +16689,7 @@ NDEFReadingEventInit[JT] var cancelable: js.UndefOr[Boolean]
 NDEFReadingEventInit[JT] var composed: js.UndefOr[Boolean]
 NDEFReadingEventInit[JT] var message: NDEFRecordInit
 NDEFReadingEventInit[JT] var scoped: js.UndefOr[Boolean]
-NDEFReadingEventInit[JT] var serialNumber: js.UndefOr[AbortSignal]
+NDEFReadingEventInit[JT] var serialNumber: js.UndefOr[String]
 NDEFRecord[JC] def data: js.typedarray.DataView
 NDEFRecord[JC] def encoding: js.UndefOr[String]
 NDEFRecord[JC] def id: js.UndefOr[String]

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -16689,7 +16689,7 @@ NDEFReadingEventInit[JT] var cancelable: js.UndefOr[Boolean]
 NDEFReadingEventInit[JT] var composed: js.UndefOr[Boolean]
 NDEFReadingEventInit[JT] var message: NDEFRecordInit
 NDEFReadingEventInit[JT] var scoped: js.UndefOr[Boolean]
-NDEFReadingEventInit[JT] var serialNumber: js.UndefOr[AbortSignal]
+NDEFReadingEventInit[JT] var serialNumber: js.UndefOr[String]
 NDEFRecord[JC] def data: js.typedarray.DataView
 NDEFRecord[JC] def encoding: js.UndefOr[String]
 NDEFRecord[JC] def id: js.UndefOr[String]

--- a/dom/src/main/scala/org/scalajs/dom/NDEFReadingEventInit.scala
+++ b/dom/src/main/scala/org/scalajs/dom/NDEFReadingEventInit.scala
@@ -15,7 +15,7 @@ trait NDEFReadingEventInit extends EventInit {
   /** A string with the name of the event. It is case-sensitive and browsers always set it to reading. Default is "" an
     * empty string
     */
-  var serialNumber: js.UndefOr[AbortSignal] = js.undefined
+  var serialNumber: js.UndefOr[String] = js.undefined
 
   /** An object that, in addition of the properties defined in Event(), can have the following properties: serialNumber;
     * message


### PR DESCRIPTION
I did a quick re-review of the WebNFC again and this should be it: https://github.com/scala-js/scala-js-dom/pull/806