### PR TITLE
Generic error event for EventSource

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -2157,7 +2157,7 @@ EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 EventSource[JC] def close(): Unit
 EventSource[JC] def dispatchEvent(evt: Event): Boolean
-EventSource[JC] var onerror: js.Function1[ErrorEvent, _]
+EventSource[JC] var onerror: js.Function1[Event, _]
 EventSource[JC] var onmessage: js.Function1[MessageEvent, _]
 EventSource[JC] var onopen: js.Function1[Event, _]
 EventSource[JC] def readyState: Int

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -2157,7 +2157,7 @@ EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Fu
 EventSource[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
 EventSource[JC] def close(): Unit
 EventSource[JC] def dispatchEvent(evt: Event): Boolean
-EventSource[JC] var onerror: js.Function1[ErrorEvent, _]
+EventSource[JC] var onerror: js.Function1[Event, _]
 EventSource[JC] var onmessage: js.Function1[MessageEvent, _]
 EventSource[JC] var onopen: js.Function1[Event, _]
 EventSource[JC] def readyState: Int

--- a/dom/src/main/scala/org/scalajs/dom/EventSource.scala
+++ b/dom/src/main/scala/org/scalajs/dom/EventSource.scala
@@ -41,7 +41,7 @@ class EventSource private[this] extends EventTarget {
 
   var onmessage: js.Function1[MessageEvent, _] = js.native
 
-  var onerror: js.Function1[ErrorEvent, _] = js.native
+  var onerror: js.Function1[Event, _] = js.native
 
   /** The close() method must abort any instances of the fetch algorithm started for this EventSource object, and must
     * set the readyState attribute to CLOSED. W3C 2012


### PR DESCRIPTION
According to MDN the error of an EventSource is a generic Event instead of an ErrorEvent: https://developer.mozilla.org/en-US/docs/Web/API/EventSource/error_event

Just caught one of these underspecified errors in the wild :) 
