### PR TITLE
URL constructor for Worker

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16490,7 +16490,7 @@ LockOptions[JT] var mode: js.UndefOr[LockMode]
 LockOptions[JT] var signal: js.UndefOr[AbortSignal]
 LockOptions[JT] var steal: js.UndefOr[Boolean]
 MIMEType[JT]
-MIMEType[SO] val `application/xhtml+xml` = "application/xhtml+xml".asInstanceOf[MIMEType]
+MIMEType[SO] val `application/xhtml+xml` =  "application/xhtml+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
@@ -17288,7 +17288,7 @@ PermissionName[JT]
 PermissionName[SO] val geolocation: PermissionName
 PermissionName[SO] val midi: PermissionName
 PermissionName[SO] val notifications: PermissionName
-PermissionName[SO] val `persistent-storage` = "persistent-storage".asInstanceOf[PermissionName]
+PermissionName[SO] val `persistent-storage` =  "persistent-storage".asInstanceOf[PermissionName]
 PermissionName[SO] val push: PermissionName
 PermissionState[JT]
 PermissionState[SO] val denied: PermissionState
@@ -17685,9 +17685,9 @@ RTCSessionDescriptionInit[SO] def apply(`type`: js.UndefOr[RTCSdpType]?, sdp: js
 RTCSignalingState[JT]
 RTCSignalingState[SO] val closed: RTCSignalingState
 RTCSignalingState[SO] val `have-local-offer` = "have-local-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-local-pranswer` = "have-local-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-local-pranswer` =  "have-local-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val `have-remote-offer` = "have-remote-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-remote-pranswer` = "have-remote-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-remote-pranswer` =  "have-remote-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val stable: RTCSignalingState
 RTCStats[JT] val id: String
 RTCStats[JT] val timestamp: Double
@@ -17757,9 +17757,9 @@ ReadableStreamUnderlyingSource[JT] var `type`: js.UndefOr[ReadableStreamType]
 ReferrerPolicy[JT]
 ReferrerPolicy[SO] val empty: ReferrerPolicy
 ReferrerPolicy[SO] val `no-referrer` = "no-referrer".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `no-referrer-when-downgrade` = "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `no-referrer-when-downgrade` =  "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `origin-only` = "origin-only".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `origin-when-cross-origin` = "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `origin-when-cross-origin` =  "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `unsafe-url` = "unsafe-url".asInstanceOf[ReferrerPolicy]
 Request[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Request[JC] def blob(): js.Promise[Blob]

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16490,7 +16490,7 @@ LockOptions[JT] var mode: js.UndefOr[LockMode]
 LockOptions[JT] var signal: js.UndefOr[AbortSignal]
 LockOptions[JT] var steal: js.UndefOr[Boolean]
 MIMEType[JT]
-MIMEType[SO] val `application/xhtml+xml` =  "application/xhtml+xml".asInstanceOf[MIMEType]
+MIMEType[SO] val `application/xhtml+xml` = "application/xhtml+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
@@ -17288,7 +17288,7 @@ PermissionName[JT]
 PermissionName[SO] val geolocation: PermissionName
 PermissionName[SO] val midi: PermissionName
 PermissionName[SO] val notifications: PermissionName
-PermissionName[SO] val `persistent-storage` =  "persistent-storage".asInstanceOf[PermissionName]
+PermissionName[SO] val `persistent-storage` = "persistent-storage".asInstanceOf[PermissionName]
 PermissionName[SO] val push: PermissionName
 PermissionState[JT]
 PermissionState[SO] val denied: PermissionState
@@ -17685,9 +17685,9 @@ RTCSessionDescriptionInit[SO] def apply(`type`: js.UndefOr[RTCSdpType]?, sdp: js
 RTCSignalingState[JT]
 RTCSignalingState[SO] val closed: RTCSignalingState
 RTCSignalingState[SO] val `have-local-offer` = "have-local-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-local-pranswer` =  "have-local-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-local-pranswer` = "have-local-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val `have-remote-offer` = "have-remote-offer".asInstanceOf[RTCSignalingState]
-RTCSignalingState[SO] val `have-remote-pranswer` =  "have-remote-pranswer".asInstanceOf[RTCSignalingState]
+RTCSignalingState[SO] val `have-remote-pranswer` = "have-remote-pranswer".asInstanceOf[RTCSignalingState]
 RTCSignalingState[SO] val stable: RTCSignalingState
 RTCStats[JT] val id: String
 RTCStats[JT] val timestamp: Double
@@ -17757,9 +17757,9 @@ ReadableStreamUnderlyingSource[JT] var `type`: js.UndefOr[ReadableStreamType]
 ReferrerPolicy[JT]
 ReferrerPolicy[SO] val empty: ReferrerPolicy
 ReferrerPolicy[SO] val `no-referrer` = "no-referrer".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `no-referrer-when-downgrade` =  "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `no-referrer-when-downgrade` = "no-referrer-when-downgrade".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `origin-only` = "origin-only".asInstanceOf[ReferrerPolicy]
-ReferrerPolicy[SO] val `origin-when-cross-origin` =  "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
+ReferrerPolicy[SO] val `origin-when-cross-origin` = "origin-when-cross-origin".asInstanceOf[ReferrerPolicy]
 ReferrerPolicy[SO] val `unsafe-url` = "unsafe-url".asInstanceOf[ReferrerPolicy]
 Request[JC] def arrayBuffer(): js.Promise[ArrayBuffer]
 Request[JC] def blob(): js.Promise[Blob]

--- a/dom/src/main/scala/org/scalajs/dom/Worker.scala
+++ b/dom/src/main/scala/org/scalajs/dom/Worker.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js.annotation._
 @js.native
 @JSGlobal
 class Worker extends AbstractWorker {
-  
+
   def this(scriptURL: String, options: WorkerOptions) = this()
   def this(scriptURL: String) = this()
   def this(scriptURL: URL, options: WorkerOptions) = this()

--- a/dom/src/main/scala/org/scalajs/dom/Worker.scala
+++ b/dom/src/main/scala/org/scalajs/dom/Worker.scala
@@ -18,9 +18,12 @@ import scala.scalajs.js.annotation._
   */
 @js.native
 @JSGlobal
-class Worker(scriptURL: String, options: WorkerOptions) extends AbstractWorker {
-
-  def this(scriptURL: String) = this(scriptURL, js.native)
+class Worker extends AbstractWorker {
+  
+  def this(scriptURL: String, options: WorkerOptions) = this()
+  def this(scriptURL: String) = this()
+  def this(scriptURL: URL, options: WorkerOptions) = this()
+  def this(scriptURL: URL) = this()
 
   /** The Worker.onmessage property represents an EventHandler, that is a function to be called when the message event
     * occurs. These events are of type MessageEvent and will be called when the worker calls its own postMessage()


### PR DESCRIPTION
This PR adds two constructors for the Worker class which use the URL object rather than a String. This is relevant because some bundles like Parcel, even enforce you to use URL rather than a string.
More info about it here: https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker#url
