### PR TITLE
Proposal for MathML base class

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16495,6 +16495,122 @@ MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/xml` = "text/xml".asInstanceOf[MIMEType]
+MathMLElement[JC] var accessKey: String
+MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MathMLElement[JC] def after(nodes: Node | String*): Unit
+MathMLElement[JC] def append(nodes: Node | String*): Unit
+MathMLElement[JC] def appendChild(newChild: Node): Node
+MathMLElement[JC] def attachShadow(init: ShadowRootInit): ShadowRoot
+MathMLElement[JC] def attributes: NamedNodeMap
+MathMLElement[JC] def baseURI: String
+MathMLElement[JC] def before(nodes: Node | String*): Unit
+MathMLElement[JC] def childElementCount: Int
+MathMLElement[JC] def childNodes: NodeList[Node]
+MathMLElement[JC] def children: HTMLCollection[Element]
+MathMLElement[JC] var classList: DOMTokenList
+MathMLElement[JC] def clientHeight: Int
+MathMLElement[JC] def clientLeft: Int
+MathMLElement[JC] def clientTop: Int
+MathMLElement[JC] def clientWidth: Int
+MathMLElement[JC] def cloneNode(deep: Boolean?): Node
+MathMLElement[JC] def closest(selector: String): Element
+MathMLElement[JC] def compareDocumentPosition(other: Node): Int
+MathMLElement[JC] def contains(otherNode: Node): Boolean
+MathMLElement[JC] def dispatchEvent(evt: Event): Boolean
+MathMLElement[JC] def firstChild: Node
+MathMLElement[JC] def firstElementChild: Element
+MathMLElement[JC] def getAttribute(name: String): String
+MathMLElement[JC] def getAttributeNS(namespaceURI: String, localName: String): String
+MathMLElement[JC] def getAttributeNode(name: String): Attr
+MathMLElement[JC] def getAttributeNodeNS(namespaceURI: String, localName: String): Attr
+MathMLElement[JC] def getBoundingClientRect(): DOMRect
+MathMLElement[JC] def getClientRects(): DOMRectList
+MathMLElement[JC] def getElementsByClassName(classNames: String): HTMLCollection[Element]
+MathMLElement[JC] def getElementsByTagName(name: String): HTMLCollection[Element]
+MathMLElement[JC] def getElementsByTagNameNS(namespaceURI: String, localName: String): HTMLCollection[Element]
+MathMLElement[JC] def hasAttribute(name: String): Boolean
+MathMLElement[JC] def hasAttributeNS(namespaceURI: String, localName: String): Boolean
+MathMLElement[JC] def hasAttributes(): Boolean
+MathMLElement[JC] def hasChildNodes(): Boolean
+MathMLElement[JC] def hasPointerCapture(pointerId: Double): Boolean
+MathMLElement[JC] var id: String
+MathMLElement[JC] var innerHTML: String
+MathMLElement[JC] var innerText: String
+MathMLElement[JC] def insertAdjacentElement(position: String, element: Element): Element
+MathMLElement[JC] def insertAdjacentHTML(where: String, html: String): Unit
+MathMLElement[JC] def insertBefore(newChild: Node, refChild: Node): Node
+MathMLElement[JC] def isConnected: Boolean
+MathMLElement[JC] def isDefaultNamespace(namespaceURI: String): Boolean
+MathMLElement[JC] def isEqualNode(arg: Node): Boolean
+MathMLElement[JC] def isSameNode(other: Node): Boolean
+MathMLElement[JC] def isSupported(feature: String, version: String): Boolean
+MathMLElement[JC] def lastChild: Node
+MathMLElement[JC] def lastElementChild: Element
+MathMLElement[JC] def localName: String
+MathMLElement[JC] def lookupNamespaceURI(prefix: String): String
+MathMLElement[JC] def lookupPrefix(namespaceURI: String): String
+MathMLElement[JC] def matches(selector: String): Boolean
+MathMLElement[JC] def namespaceURI: String
+MathMLElement[JC] def nextElementSibling: Element
+MathMLElement[JC] def nextSibling: Node
+MathMLElement[JC] def nodeName: String
+MathMLElement[JC] def nodeType: Int
+MathMLElement[JC] var nodeValue: String
+MathMLElement[JC] def normalize(): Unit
+MathMLElement[JC] var onclick: js.Function1[MouseEvent, _]
+MathMLElement[JC] var oncompositionend: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncompositionstart: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncompositionupdate: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncopy: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var oncut: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var onfocusin: js.Function1[FocusEvent, _]
+MathMLElement[JC] var onfocusout: js.Function1[FocusEvent, _]
+MathMLElement[JC] var onfullscreenchange: js.Function1[Event, _]
+MathMLElement[JC] var onfullscreenerror: js.Function1[Event, _]
+MathMLElement[JC] var onload: js.Function1[Event, _]
+MathMLElement[JC] var onmousedown: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmousemove: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseout: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseover: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseup: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onpaste: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var outerHTML: String
+MathMLElement[JC] def ownerDocument: Document
+MathMLElement[JC] def parentNode: Node
+MathMLElement[JC] def prefix: String
+MathMLElement[JC] def prepend(nodes: Node | String*): Unit
+MathMLElement[JC] def previousElementSibling: Element
+MathMLElement[JC] def previousSibling: Node
+MathMLElement[JC] def querySelector(selectors: String): Element
+MathMLElement[JC] def querySelectorAll(selectors: String): NodeList[Element]
+MathMLElement[JC] def releasePointerCapture(pointerId: Double): Unit
+MathMLElement[JC] def remove(): Unit
+MathMLElement[JC] def removeAttribute(name: String): Unit
+MathMLElement[JC] def removeAttributeNS(namespaceURI: String, localName: String): Unit
+MathMLElement[JC] def removeAttributeNode(oldAttr: Attr): Attr
+MathMLElement[JC] def removeChild(oldChild: Node): Node
+MathMLElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MathMLElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MathMLElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
+MathMLElement[JC] def replaceChildren(nodes: Node | String*): Unit
+MathMLElement[JC] def replaceWith(nodes: Node | String*): Unit
+MathMLElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
+MathMLElement[JC] def requestPointerLock(): Unit
+MathMLElement[JC] def scrollHeight: Int
+MathMLElement[JC] def scrollIntoView(top: Boolean?): Unit
+MathMLElement[JC] var scrollLeft: Double
+MathMLElement[JC] var scrollTop: Double
+MathMLElement[JC] def scrollWidth: Int
+MathMLElement[JC] def setAttribute(name: String, value: String): Unit
+MathMLElement[JC] def setAttributeNS(namespaceURI: String, qualifiedName: String, value: String): Unit
+MathMLElement[JC] def setAttributeNode(newAttr: Attr): Attr
+MathMLElement[JC] def setAttributeNodeNS(newAttr: Attr): Attr
+MathMLElement[JC] def setPointerCapture(pointerId: Double): Unit
+MathMLElement[JC] def shadowRoot: ShadowRoot
+MathMLElement[JC] def tagName: String
+MathMLElement[JC] var textContent: String
+MathMLElement[JC] var xmlbase: String
 MediaDeviceInfo[JT] val deviceId: String
 MediaDeviceInfo[JT] val groupId: String
 MediaDeviceInfo[JT] val kind: MediaDeviceKind

--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -16501,13 +16501,16 @@ MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.
 MathMLElement[JC] def after(nodes: Node | String*): Unit
 MathMLElement[JC] def append(nodes: Node | String*): Unit
 MathMLElement[JC] def appendChild(newChild: Node): Node
+MathMLElement[JC] var arg: String
 MathMLElement[JC] def attachShadow(init: ShadowRootInit): ShadowRoot
 MathMLElement[JC] def attributes: NamedNodeMap
+MathMLElement[JC] var autofocus: Boolean
 MathMLElement[JC] def baseURI: String
 MathMLElement[JC] def before(nodes: Node | String*): Unit
 MathMLElement[JC] def childElementCount: Int
 MathMLElement[JC] def childNodes: NodeList[Node]
 MathMLElement[JC] def children: HTMLCollection[Element]
+MathMLElement[JC] var `class`: String
 MathMLElement[JC] var classList: DOMTokenList
 MathMLElement[JC] def clientHeight: Int
 MathMLElement[JC] def clientLeft: Int
@@ -16517,7 +16520,9 @@ MathMLElement[JC] def cloneNode(deep: Boolean?): Node
 MathMLElement[JC] def closest(selector: String): Element
 MathMLElement[JC] def compareDocumentPosition(other: Node): Int
 MathMLElement[JC] def contains(otherNode: Node): Boolean
+MathMLElement[JC] var dir: String
 MathMLElement[JC] def dispatchEvent(evt: Event): Boolean
+MathMLElement[JC] var displaystyle: Boolean
 MathMLElement[JC] def firstChild: Node
 MathMLElement[JC] def firstElementChild: Element
 MathMLElement[JC] def getAttribute(name: String): String
@@ -16540,6 +16545,7 @@ MathMLElement[JC] var innerText: String
 MathMLElement[JC] def insertAdjacentElement(position: String, element: Element): Element
 MathMLElement[JC] def insertAdjacentHTML(where: String, html: String): Unit
 MathMLElement[JC] def insertBefore(newChild: Node, refChild: Node): Node
+MathMLElement[JC] var intent: String
 MathMLElement[JC] def isConnected: Boolean
 MathMLElement[JC] def isDefaultNamespace(namespaceURI: String): Boolean
 MathMLElement[JC] def isEqualNode(arg: Node): Boolean
@@ -16551,12 +16557,16 @@ MathMLElement[JC] def localName: String
 MathMLElement[JC] def lookupNamespaceURI(prefix: String): String
 MathMLElement[JC] def lookupPrefix(namespaceURI: String): String
 MathMLElement[JC] def matches(selector: String): Boolean
+MathMLElement[JC] var mathbackground: String
+MathMLElement[JC] var mathcolor: String
+MathMLElement[JC] var mathsize: String
 MathMLElement[JC] def namespaceURI: String
 MathMLElement[JC] def nextElementSibling: Element
 MathMLElement[JC] def nextSibling: Node
 MathMLElement[JC] def nodeName: String
 MathMLElement[JC] def nodeType: Int
 MathMLElement[JC] var nodeValue: String
+MathMLElement[JC] var nonce: String
 MathMLElement[JC] def normalize(): Unit
 MathMLElement[JC] var onclick: js.Function1[MouseEvent, _]
 MathMLElement[JC] var oncompositionend: js.Function1[CompositionEvent, _]
@@ -16597,6 +16607,7 @@ MathMLElement[JC] def replaceChildren(nodes: Node | String*): Unit
 MathMLElement[JC] def replaceWith(nodes: Node | String*): Unit
 MathMLElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 MathMLElement[JC] def requestPointerLock(): Unit
+MathMLElement[JC] var scriptlevel: Int
 MathMLElement[JC] def scrollHeight: Int
 MathMLElement[JC] def scrollIntoView(top: Boolean?): Unit
 MathMLElement[JC] var scrollLeft: Double
@@ -16608,6 +16619,8 @@ MathMLElement[JC] def setAttributeNode(newAttr: Attr): Attr
 MathMLElement[JC] def setAttributeNodeNS(newAttr: Attr): Attr
 MathMLElement[JC] def setPointerCapture(pointerId: Double): Unit
 MathMLElement[JC] def shadowRoot: ShadowRoot
+MathMLElement[JC] var style: String
+MathMLElement[JC] var tabindex: Int
 MathMLElement[JC] def tagName: String
 MathMLElement[JC] var textContent: String
 MathMLElement[JC] var xmlbase: String

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -16495,6 +16495,122 @@ MIMEType[SO] val `application/xml` = "application/xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `image/svg+xml` = "image/svg+xml".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/html` = "text/html".asInstanceOf[MIMEType]
 MIMEType[SO] val `text/xml` = "text/xml".asInstanceOf[MIMEType]
+MathMLElement[JC] var accessKey: String
+MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MathMLElement[JC] def after(nodes: Node | String*): Unit
+MathMLElement[JC] def append(nodes: Node | String*): Unit
+MathMLElement[JC] def appendChild(newChild: Node): Node
+MathMLElement[JC] def attachShadow(init: ShadowRootInit): ShadowRoot
+MathMLElement[JC] def attributes: NamedNodeMap
+MathMLElement[JC] def baseURI: String
+MathMLElement[JC] def before(nodes: Node | String*): Unit
+MathMLElement[JC] def childElementCount: Int
+MathMLElement[JC] def childNodes: NodeList[Node]
+MathMLElement[JC] def children: HTMLCollection[Element]
+MathMLElement[JC] var classList: DOMTokenList
+MathMLElement[JC] def clientHeight: Int
+MathMLElement[JC] def clientLeft: Int
+MathMLElement[JC] def clientTop: Int
+MathMLElement[JC] def clientWidth: Int
+MathMLElement[JC] def cloneNode(deep: Boolean?): Node
+MathMLElement[JC] def closest(selector: String): Element
+MathMLElement[JC] def compareDocumentPosition(other: Node): Int
+MathMLElement[JC] def contains(otherNode: Node): Boolean
+MathMLElement[JC] def dispatchEvent(evt: Event): Boolean
+MathMLElement[JC] def firstChild: Node
+MathMLElement[JC] def firstElementChild: Element
+MathMLElement[JC] def getAttribute(name: String): String
+MathMLElement[JC] def getAttributeNS(namespaceURI: String, localName: String): String
+MathMLElement[JC] def getAttributeNode(name: String): Attr
+MathMLElement[JC] def getAttributeNodeNS(namespaceURI: String, localName: String): Attr
+MathMLElement[JC] def getBoundingClientRect(): DOMRect
+MathMLElement[JC] def getClientRects(): DOMRectList
+MathMLElement[JC] def getElementsByClassName(classNames: String): HTMLCollection[Element]
+MathMLElement[JC] def getElementsByTagName(name: String): HTMLCollection[Element]
+MathMLElement[JC] def getElementsByTagNameNS(namespaceURI: String, localName: String): HTMLCollection[Element]
+MathMLElement[JC] def hasAttribute(name: String): Boolean
+MathMLElement[JC] def hasAttributeNS(namespaceURI: String, localName: String): Boolean
+MathMLElement[JC] def hasAttributes(): Boolean
+MathMLElement[JC] def hasChildNodes(): Boolean
+MathMLElement[JC] def hasPointerCapture(pointerId: Double): Boolean
+MathMLElement[JC] var id: String
+MathMLElement[JC] var innerHTML: String
+MathMLElement[JC] var innerText: String
+MathMLElement[JC] def insertAdjacentElement(position: String, element: Element): Element
+MathMLElement[JC] def insertAdjacentHTML(where: String, html: String): Unit
+MathMLElement[JC] def insertBefore(newChild: Node, refChild: Node): Node
+MathMLElement[JC] def isConnected: Boolean
+MathMLElement[JC] def isDefaultNamespace(namespaceURI: String): Boolean
+MathMLElement[JC] def isEqualNode(arg: Node): Boolean
+MathMLElement[JC] def isSameNode(other: Node): Boolean
+MathMLElement[JC] def isSupported(feature: String, version: String): Boolean
+MathMLElement[JC] def lastChild: Node
+MathMLElement[JC] def lastElementChild: Element
+MathMLElement[JC] def localName: String
+MathMLElement[JC] def lookupNamespaceURI(prefix: String): String
+MathMLElement[JC] def lookupPrefix(namespaceURI: String): String
+MathMLElement[JC] def matches(selector: String): Boolean
+MathMLElement[JC] def namespaceURI: String
+MathMLElement[JC] def nextElementSibling: Element
+MathMLElement[JC] def nextSibling: Node
+MathMLElement[JC] def nodeName: String
+MathMLElement[JC] def nodeType: Int
+MathMLElement[JC] var nodeValue: String
+MathMLElement[JC] def normalize(): Unit
+MathMLElement[JC] var onclick: js.Function1[MouseEvent, _]
+MathMLElement[JC] var oncompositionend: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncompositionstart: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncompositionupdate: js.Function1[CompositionEvent, _]
+MathMLElement[JC] var oncopy: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var oncut: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var onfocusin: js.Function1[FocusEvent, _]
+MathMLElement[JC] var onfocusout: js.Function1[FocusEvent, _]
+MathMLElement[JC] var onfullscreenchange: js.Function1[Event, _]
+MathMLElement[JC] var onfullscreenerror: js.Function1[Event, _]
+MathMLElement[JC] var onload: js.Function1[Event, _]
+MathMLElement[JC] var onmousedown: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmousemove: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseout: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseover: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onmouseup: js.Function1[MouseEvent, _]
+MathMLElement[JC] var onpaste: js.Function1[ClipboardEvent, _]
+MathMLElement[JC] var outerHTML: String
+MathMLElement[JC] def ownerDocument: Document
+MathMLElement[JC] def parentNode: Node
+MathMLElement[JC] def prefix: String
+MathMLElement[JC] def prepend(nodes: Node | String*): Unit
+MathMLElement[JC] def previousElementSibling: Element
+MathMLElement[JC] def previousSibling: Node
+MathMLElement[JC] def querySelector(selectors: String): Element
+MathMLElement[JC] def querySelectorAll(selectors: String): NodeList[Element]
+MathMLElement[JC] def releasePointerCapture(pointerId: Double): Unit
+MathMLElement[JC] def remove(): Unit
+MathMLElement[JC] def removeAttribute(name: String): Unit
+MathMLElement[JC] def removeAttributeNS(namespaceURI: String, localName: String): Unit
+MathMLElement[JC] def removeAttributeNode(oldAttr: Attr): Attr
+MathMLElement[JC] def removeChild(oldChild: Node): Node
+MathMLElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], options: EventListenerOptions): Unit
+MathMLElement[JC] def removeEventListener[T <: Event](`type`: String, listener: js.Function1[T, _], useCapture: Boolean?): Unit
+MathMLElement[JC] def replaceChild(newChild: Node, oldChild: Node): Node
+MathMLElement[JC] def replaceChildren(nodes: Node | String*): Unit
+MathMLElement[JC] def replaceWith(nodes: Node | String*): Unit
+MathMLElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
+MathMLElement[JC] def requestPointerLock(): Unit
+MathMLElement[JC] def scrollHeight: Int
+MathMLElement[JC] def scrollIntoView(top: Boolean?): Unit
+MathMLElement[JC] var scrollLeft: Double
+MathMLElement[JC] var scrollTop: Double
+MathMLElement[JC] def scrollWidth: Int
+MathMLElement[JC] def setAttribute(name: String, value: String): Unit
+MathMLElement[JC] def setAttributeNS(namespaceURI: String, qualifiedName: String, value: String): Unit
+MathMLElement[JC] def setAttributeNode(newAttr: Attr): Attr
+MathMLElement[JC] def setAttributeNodeNS(newAttr: Attr): Attr
+MathMLElement[JC] def setPointerCapture(pointerId: Double): Unit
+MathMLElement[JC] def shadowRoot: ShadowRoot
+MathMLElement[JC] def tagName: String
+MathMLElement[JC] var textContent: String
+MathMLElement[JC] var xmlbase: String
 MediaDeviceInfo[JT] val deviceId: String
 MediaDeviceInfo[JT] val groupId: String
 MediaDeviceInfo[JT] val kind: MediaDeviceKind

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -16501,13 +16501,16 @@ MathMLElement[JC] def addEventListener[T <: Event](`type`: String, listener: js.
 MathMLElement[JC] def after(nodes: Node | String*): Unit
 MathMLElement[JC] def append(nodes: Node | String*): Unit
 MathMLElement[JC] def appendChild(newChild: Node): Node
+MathMLElement[JC] var arg: String
 MathMLElement[JC] def attachShadow(init: ShadowRootInit): ShadowRoot
 MathMLElement[JC] def attributes: NamedNodeMap
+MathMLElement[JC] var autofocus: Boolean
 MathMLElement[JC] def baseURI: String
 MathMLElement[JC] def before(nodes: Node | String*): Unit
 MathMLElement[JC] def childElementCount: Int
 MathMLElement[JC] def childNodes: NodeList[Node]
 MathMLElement[JC] def children: HTMLCollection[Element]
+MathMLElement[JC] var `class`: String
 MathMLElement[JC] var classList: DOMTokenList
 MathMLElement[JC] def clientHeight: Int
 MathMLElement[JC] def clientLeft: Int
@@ -16517,7 +16520,9 @@ MathMLElement[JC] def cloneNode(deep: Boolean?): Node
 MathMLElement[JC] def closest(selector: String): Element
 MathMLElement[JC] def compareDocumentPosition(other: Node): Int
 MathMLElement[JC] def contains(otherNode: Node): Boolean
+MathMLElement[JC] var dir: String
 MathMLElement[JC] def dispatchEvent(evt: Event): Boolean
+MathMLElement[JC] var displaystyle: Boolean
 MathMLElement[JC] def firstChild: Node
 MathMLElement[JC] def firstElementChild: Element
 MathMLElement[JC] def getAttribute(name: String): String
@@ -16540,6 +16545,7 @@ MathMLElement[JC] var innerText: String
 MathMLElement[JC] def insertAdjacentElement(position: String, element: Element): Element
 MathMLElement[JC] def insertAdjacentHTML(where: String, html: String): Unit
 MathMLElement[JC] def insertBefore(newChild: Node, refChild: Node): Node
+MathMLElement[JC] var intent: String
 MathMLElement[JC] def isConnected: Boolean
 MathMLElement[JC] def isDefaultNamespace(namespaceURI: String): Boolean
 MathMLElement[JC] def isEqualNode(arg: Node): Boolean
@@ -16551,12 +16557,16 @@ MathMLElement[JC] def localName: String
 MathMLElement[JC] def lookupNamespaceURI(prefix: String): String
 MathMLElement[JC] def lookupPrefix(namespaceURI: String): String
 MathMLElement[JC] def matches(selector: String): Boolean
+MathMLElement[JC] var mathbackground: String
+MathMLElement[JC] var mathcolor: String
+MathMLElement[JC] var mathsize: String
 MathMLElement[JC] def namespaceURI: String
 MathMLElement[JC] def nextElementSibling: Element
 MathMLElement[JC] def nextSibling: Node
 MathMLElement[JC] def nodeName: String
 MathMLElement[JC] def nodeType: Int
 MathMLElement[JC] var nodeValue: String
+MathMLElement[JC] var nonce: String
 MathMLElement[JC] def normalize(): Unit
 MathMLElement[JC] var onclick: js.Function1[MouseEvent, _]
 MathMLElement[JC] var oncompositionend: js.Function1[CompositionEvent, _]
@@ -16597,6 +16607,7 @@ MathMLElement[JC] def replaceChildren(nodes: Node | String*): Unit
 MathMLElement[JC] def replaceWith(nodes: Node | String*): Unit
 MathMLElement[JC] def requestFullscreen(options: FullscreenOptions?): js.Promise[Unit]
 MathMLElement[JC] def requestPointerLock(): Unit
+MathMLElement[JC] var scriptlevel: Int
 MathMLElement[JC] def scrollHeight: Int
 MathMLElement[JC] def scrollIntoView(top: Boolean?): Unit
 MathMLElement[JC] var scrollLeft: Double
@@ -16608,6 +16619,8 @@ MathMLElement[JC] def setAttributeNode(newAttr: Attr): Attr
 MathMLElement[JC] def setAttributeNodeNS(newAttr: Attr): Attr
 MathMLElement[JC] def setPointerCapture(pointerId: Double): Unit
 MathMLElement[JC] def shadowRoot: ShadowRoot
+MathMLElement[JC] var style: String
+MathMLElement[JC] var tabindex: Int
 MathMLElement[JC] def tagName: String
 MathMLElement[JC] var textContent: String
 MathMLElement[JC] var xmlbase: String

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -3,8 +3,7 @@ package org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-/** The MathMLElement interface represents any MathML element.
-  */
+/** The MathMLElement interface represents any MathML element. */
 @js.native
 @JSGlobal
 abstract class MathMLElement extends Element {
@@ -21,7 +20,6 @@ abstract class MathMLElement extends Element {
   /** Corresponds to attribute xml:base on the given element. */
   var xmlbase: String = js.native
 
-
   var autofocus: Boolean = js.native
   var `class`: String = js.native
   var dir: String = js.native
@@ -33,7 +31,6 @@ abstract class MathMLElement extends Element {
   var scriptlevel: Int = js.native
   var style: String = js.native
   var tabindex: Int = js.native
-
 
   var intent: String = js.native
   var arg: String = js.native

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -21,7 +21,6 @@ abstract class MathMLElement extends Element {
   /** Corresponds to attribute xml:base on the given element. */
   var xmlbase: String = js.native
 
-  /** https://w3c.github.io/mathml-core/#global-attributes */
 
   var autofocus: Boolean = js.native
   var `class`: String = js.native

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -1,0 +1,26 @@
+package org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** Represents a Scala.js facade for the MathML element. Documentation for MathML elements can be found at:
+  * https://developer.mozilla.org/en-US/docs/Web/MathML/Element
+  *
+  * All MathMl elements implement this interface.
+  */
+@js.native
+@JSGlobal
+abstract class MathMLElement extends Element {
+  var onclick: js.Function1[MouseEvent, _] = js.native
+  var onmouseover: js.Function1[MouseEvent, _] = js.native
+  var onmouseout: js.Function1[MouseEvent, _] = js.native
+  var onmousedown: js.Function1[MouseEvent, _] = js.native
+  var onmouseup: js.Function1[MouseEvent, _] = js.native
+  var onmousemove: js.Function1[MouseEvent, _] = js.native
+  var onload: js.Function1[Event, _] = js.native
+  var onfocusin: js.Function1[FocusEvent, _] = js.native
+  var onfocusout: js.Function1[FocusEvent, _] = js.native
+
+  /** Corresponds to attribute xml:base on the given element. */
+  var `xmlbase`: String = js.native
+}

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -10,7 +10,7 @@ import scala.scalajs.js.annotation._
   */
 @js.native
 @JSGlobal
-abstract class MathMLElement extends Element {
+abstract class MathMLElement extends org.scalajs.dom.Element {
   var onclick: js.Function1[MouseEvent, _] = js.native
   var onmouseover: js.Function1[MouseEvent, _] = js.native
   var onmouseout: js.Function1[MouseEvent, _] = js.native

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -23,4 +23,24 @@ abstract class MathMLElement extends Element {
 
   /** Corresponds to attribute xml:base on the given element. */
   var xmlbase: String = js.native
+
+  /** https://w3c.github.io/mathml-core/#global-attributes */
+
+  var autofocus: Boolean = js.native
+  var `class`: String = js.native
+  var dir: String = js.native
+  var displaystyle: Boolean = js.native
+  var mathbackground: String = js.native
+  var mathcolor: String = js.native
+  var mathsize: String = js.native
+  var nonce: String = js.native
+  var scriptlevel: Int = js.native
+  var style: String = js.native
+  var tabindex: Int = js.native
+
+  /** https://w3c.github.io/mathml-core/#other-valid-attributes */
+
+  var intent: String = js.native
+  var arg: String = js.native
+
 }

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -10,7 +10,7 @@ import scala.scalajs.js.annotation._
   */
 @js.native
 @JSGlobal
-abstract class MathMLElement extends org.scalajs.dom.Element {
+abstract class MathMLElement extends Element {
   var onclick: js.Function1[MouseEvent, _] = js.native
   var onmouseover: js.Function1[MouseEvent, _] = js.native
   var onmouseout: js.Function1[MouseEvent, _] = js.native
@@ -22,5 +22,5 @@ abstract class MathMLElement extends org.scalajs.dom.Element {
   var onfocusout: js.Function1[FocusEvent, _] = js.native
 
   /** Corresponds to attribute xml:base on the given element. */
-  var `xmlbase`: String = js.native
+  var xmlbase: String = js.native
 }

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -38,7 +38,6 @@ abstract class MathMLElement extends Element {
   var style: String = js.native
   var tabindex: Int = js.native
 
-  /** https://w3c.github.io/mathml-core/#other-valid-attributes */
 
   var intent: String = js.native
   var arg: String = js.native

--- a/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
+++ b/dom/src/main/scala/org/scalajs/dom/MathMLElement.scala
@@ -3,10 +3,7 @@ package org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-/** Represents a Scala.js facade for the MathML element. Documentation for MathML elements can be found at:
-  * https://developer.mozilla.org/en-US/docs/Web/MathML/Element
-  *
-  * All MathMl elements implement this interface.
+/** The MathMLElement interface represents any MathML element.
   */
 @js.native
 @JSGlobal

--- a/tests-shared/src/main/scala/org/scalajs/dom/tests/shared/BrowserTests.scala
+++ b/tests-shared/src/main/scala/org/scalajs/dom/tests/shared/BrowserTests.scala
@@ -137,8 +137,8 @@ trait BrowserTests extends WebCryptoApiTests {
     import org.scalajs.dom.{ImageData, ImageDataSettings, PredefinedColorSpace}
     import PredefinedColorSpace._
 
-    val width:Int = 200
-    val height:Int = 100
+    val width: Int = 200
+    val height: Int = 100
 
     // new ImageData(width, height)
     val imgDat1: ImageData = new ImageData(width, height)
@@ -164,7 +164,8 @@ trait BrowserTests extends WebCryptoApiTests {
     assertEquals(imgDat3.data.length, width * height * 4)
 
     // new ImageData(dataArray, width, height, settings)
-    val defaultImageData: ImageData = new ImageData(imgDat3.data, width, height, new ImageDataSettings { colorSpace = `display-p3` })
+    val defaultImageData: ImageData =
+      new ImageData(imgDat3.data, width, height, new ImageDataSettings { colorSpace = `display-p3` })
     assertEquals(defaultImageData.width, width)
     assertEquals(defaultImageData.height, height)
   }


### PR DESCRIPTION
* run `sbt prePR` [x]
* commit changes to `api-reports` [x]
 
This proposes a base class for MathML elements. 

If it gets merged / agreed, I'd propose to follow it up with concrete elements following the style of the SVG elements, and the documentation here;

https://developer.mozilla.org/en-US/docs/Web/MathML

Related;
- https://github.com/raquo/scala-dom-types/pulls
- https://github.com/raquo/Laminar/issues/172

cc @raquo 