### PR TITLE
literal types

### DIFF
--- a/dom/src/main/scala-3/org/scalajs/dom/HtmlLiterals.scala
+++ b/dom/src/main/scala-3/org/scalajs/dom/HtmlLiterals.scala
@@ -1,7 +1,12 @@
 package org.scalajs.dom
 
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
 /** Short aliases of all the dom.HTMLThing classes */
-object HTMLLiterals {
+@js.native
+@JSGlobal
+object literals extends js.Any:        
     def createElement(tagName: "a"): HTMLAnchorElement = js.native
     def createElement(tagName: "audio"): HTMLAudioElement = js.native
     def createElement(tagName: "area"): HTMLAreaElement = js.native
@@ -58,4 +63,3 @@ object HTMLLiterals {
     def createElement(tagName: "ul"): HTMLUListElement = js.native
     def createElement(tagName: "unknown"): HTMLUnknownElement = js.native
     def createElement(tagName: "video"): HTMLVideoElement = js.native
-}


### PR DESCRIPTION
* run `sbt prePR` - done
* commit changes to `api-reports` - done

DISCLAIMER: 

I created an object called HTML Literals i what looked like the right place, then made an AI generate the code according to the design sketched out in the PR. It matches my understanding of the ask.

It's scala 3 only, because doing it also for scala 2.13 means seperating 2.13 and 2.12, which would introduce (at least for me) a headspace problem. Scala 2 & 3 are already seperate, making that leg of the task easy - I would propose to do scala 3 only to ease the maintainer burden. 

If there is interest in merging, then I'll put my time behind the PR and try and help it over the line. 

I did not spend a lot of time here, so I shall not feel offended, if there is little appetite, either :-). I wish to help, not burden.
