### PR TITLE
Make dom.URL.searchParams readonly (val)

### DIFF
--- a/api-reports/2_12.txt
+++ b/api-reports/2_12.txt
@@ -27196,7 +27196,7 @@ URL[JC] var pathname: String
 URL[JC] var port: String
 URL[JC] var protocol: String
 URL[JC] var search: String
-URL[JC] var searchParams: URLSearchParams
+URL[JC] val searchParams: URLSearchParams
 URL[JC] var username: String
 URL[JO] def createObjectURL(blob: Blob): String
 URL[JO] def createObjectURL(src: MediaSource): String

--- a/api-reports/2_13.txt
+++ b/api-reports/2_13.txt
@@ -27196,7 +27196,7 @@ URL[JC] var pathname: String
 URL[JC] var port: String
 URL[JC] var protocol: String
 URL[JC] var search: String
-URL[JC] var searchParams: URLSearchParams
+URL[JC] val searchParams: URLSearchParams
 URL[JC] var username: String
 URL[JO] def createObjectURL(blob: Blob): String
 URL[JO] def createObjectURL(src: MediaSource): String

--- a/dom/src/main/scala/org/scalajs/dom/URL.scala
+++ b/dom/src/main/scala/org/scalajs/dom/URL.scala
@@ -62,5 +62,5 @@ class URL(url: String, base: String = js.native) extends js.Object {
   /** Is a DOMString containing a '#' followed by the fragment identifier of the URL. */
   var hash: String = js.native
 
-  var searchParams: URLSearchParams = js.native
+  val searchParams: URLSearchParams = js.native
 }


### PR DESCRIPTION
`URL.searchParams` is a readonly field. The URLSearchParams object itself is mutable, but the reference is immutable and stable.

https://url.spec.whatwg.org/#dom-url-searchparams
https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams

Note – in JS strict mode (typical for JS bundlers), `const url = new URL('http://localhost/').searchParams = new URLSearchParams({foo: "123"})` throws a `TypeError` saying that searchParams is a readonly field, but in the browser dev console, such an assignment will fail silently instead. You can check that the assignment failed by printing `url.searchParams.size == 0` or comparing the new and old references.

My testing and reading of the spec seems to confirm that it should be a `val`, not a `def`, at least I couldn't find anything contradicting that.