### PR TITLE
Upgrade to sbt 1.11.3 and sbt-ci-release 1.11.0.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -55,6 +55,7 @@ object Build {
     .configure(commonSettings, crossScala, preventPublication)
     .settings(
       libraryDependencies += Dep.scalafixCore.value,
+      allowUnsafeScalaLibUpgrade := true,
     )
 
   lazy val testsShared = project

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium"     % "1.1.1"
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"        % "0.10.4")
-addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"       % "0.13.0")
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"      % "1.5.12")
-addSbtPlugin("com.lihaoyi"   % "scalatex-sbt-plugin" % "0.3.11")
-addSbtPlugin("org.scala-js"  % "sbt-scalajs"         % "1.7.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"        % "2.5.2")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"        % "0.10.4")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"       % "0.13.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"      % "1.11.1")
+addSbtPlugin("com.lihaoyi"    % "scalatex-sbt-plugin" % "0.3.11")
+addSbtPlugin("org.scala-js"   % "sbt-scalajs"         % "1.7.1")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.2")


### PR DESCRIPTION
This is necessary to publish to the new Maven Central Portal.