### PR TITLE
PerformanceEntry: Change duration type from Int to Double

### DIFF
--- a/dom/src/main/scala/org/scalajs/dom/PerformanceEntry.scala
+++ b/dom/src/main/scala/org/scalajs/dom/PerformanceEntry.scala
@@ -27,7 +27,7 @@ class PerformanceEntry extends js.Object {
   /** The duration of the performance entry. The meaning of this property depends on the value of this entry's
     * [[entryType]].
     */
-  def duration: Int = js.native
+  def duration: Double = js.native
 
   /** The type of performance metric that this entry represents. */
   def entryType: String = js.native


### PR DESCRIPTION
I'm getting ClassCastExceptions about a number not being convertible to a java.lang.Integer. The stack trace is unclear but I think it's coming from code that's reading the duration field of a PerformanceMeaure. And MDN says it's a DOMHighResTimeStamp which it says is a double.
